### PR TITLE
combine with now grows to fit both images in

### DIFF
--- a/src/main/kotlin/org/codetome/zircon/api/graphics/TextImage.kt
+++ b/src/main/kotlin/org/codetome/zircon/api/graphics/TextImage.kt
@@ -59,6 +59,8 @@ interface TextImage : DrawSurface, Styleable, Drawable {
      * [TextCharacter] in the supplied `textImage` will be used.
      * This method creates a new object and **both** original [TextImage]s are left
      * untouched!
+     * The size of the new [TextImage] will be the size of the current [TextImage] UNLESS the offset + `textImage`
+     * would overflow. In that case the new [TextImage] will be resized to fit the new TextImage accordingly
      * @param textImage the image which will be drawn onto `this` image
      * @param offset The position on the target image where the `textImage`'s top left corner will be
      */

--- a/src/main/kotlin/org/codetome/zircon/internal/graphics/DefaultTextImage.kt
+++ b/src/main/kotlin/org/codetome/zircon/internal/graphics/DefaultTextImage.kt
@@ -116,8 +116,11 @@ class DefaultTextImage(size: Size,
 
     @Synchronized
     override fun combineWith(textImage: TextImage, offset: Position): TextImage {
+        val columns = Math.max(getBoundableSize().columns, offset.column + textImage.getBoundableSize().columns)
+        val rows = Math.max(getBoundableSize().rows, offset.row + textImage.getBoundableSize().rows)
+
         val surface = TextImageBuilder.newBuilder()
-                .size(getBoundableSize())
+                .size(Size.of(columns, rows))
                 .toCopy(copyArray(buffer, getBoundableSize(), TextCharacterBuilder.EMPTY))
                 .build()
         surface.draw(textImage, offset)

--- a/src/test/kotlin/org/codetome/zircon/internal/graphics/DefaultTextImageTest.kt
+++ b/src/test/kotlin/org/codetome/zircon/internal/graphics/DefaultTextImageTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.codetome.zircon.api.Position
 import org.codetome.zircon.api.Position.Companion.DEFAULT_POSITION
 import org.codetome.zircon.api.Position.Companion.OFFSET_1x1
+import org.codetome.zircon.api.Position.Companion.of
 import org.codetome.zircon.api.Size
 import org.codetome.zircon.api.TextCharacter
 import org.codetome.zircon.api.behavior.DrawSurface
@@ -111,6 +112,43 @@ class DefaultTextImageTest {
 
         assertThat(target.getCharacterAt(DEFAULT_POSITION).get())
                 .isEqualTo(SET_ALL_CHAR)
+    }
+
+    @Test
+    fun givenATextImageThatOverFlowsWhenCombinedThenResizeNewTextImage(){
+        val sourceChar = TextCharacterBuilder.DEFAULT_CHARACTER.withCharacter('x')
+        val imageChar = TextCharacterBuilder.DEFAULT_CHARACTER.withCharacter('+')
+
+        val source = TextImageBuilder.newBuilder()
+                .size(Size.of(3, 1))
+                .filler(sourceChar)
+                .build()
+
+        val newImage = TextImageBuilder.newBuilder()
+                .size(Size.of(2, 1))
+                .filler(imageChar)
+                .build()
+
+        val result = source.combineWith(newImage, Position(0, 2))
+        assertThat(result.getBoundableSize()).isEqualTo(Size.of(3, 3))
+
+        //first row should all be x's
+        for(x in 0..2){
+            assertThat(result.getCharacterAt(of(x, 0)).get().getCharacter()).isEqualTo('x')
+        }
+
+        //as the second image was offset by 2 rows there should be nothing here
+        for(x in 0..2){
+            assertThat(result.getCharacterAt(of(x, 1)).get().getCharacter()).isEqualTo(' ')
+        }
+
+        //the 3rd row should be + for the first 2 columns (as that's the size of the second image)
+        for(x in 0..1){
+            assertThat(result.getCharacterAt(of(x, 2)).get().getCharacter()).isEqualTo('+')
+        }
+
+        //the bottom right character should be blank
+        assertThat(result.getCharacterAt(of(2, 2)).get().getCharacter()).isEqualTo(' ')
     }
 
     @Test


### PR DESCRIPTION
Fixed the TextImage so that when you combine them they will autogrow (if needed) to include the second image in its bounds.

fixes issue 
https://github.com/Hexworks/zircon/issues/69