### PR TITLE
Redraw the swing terminal on Canvas.paint().

### DIFF
--- a/zircon.swing/src/main/kotlin/org/codetome/zircon/internal/terminal/SwingTerminal.kt
+++ b/zircon.swing/src/main/kotlin/org/codetome/zircon/internal/terminal/SwingTerminal.kt
@@ -39,7 +39,6 @@ class SwingTerminal(
         canvas.preferredSize = Dimension(
                 getSupportedFontSize().xLength * getBoundableSize().xLength,
                 getSupportedFontSize().yLength * getBoundableSize().yLength)
-        canvas.ignoreRepaint = true
         canvas.isFocusable = true
         canvas.requestFocusInWindow()
         canvas.minimumSize = Dimension(initialFont.getWidth(), initialFont.getHeight())

--- a/zircon.swing/src/main/kotlin/org/codetome/zircon/internal/terminal/SwingTerminalFrame.kt
+++ b/zircon.swing/src/main/kotlin/org/codetome/zircon/internal/terminal/SwingTerminalFrame.kt
@@ -6,6 +6,7 @@ import org.codetome.zircon.api.font.Font
 import org.codetome.zircon.api.terminal.config.DeviceConfiguration
 import java.awt.Canvas
 import java.awt.Frame
+import java.awt.Graphics
 import java.awt.event.WindowEvent
 import java.awt.event.WindowStateListener
 import javax.swing.JFrame
@@ -19,7 +20,7 @@ class SwingTerminalFrame(title: String = "ZirconTerminal",
                          deviceConfiguration: DeviceConfiguration = DeviceConfigurationBuilder.DEFAULT,
                          font: Font,
                          fullScreen: Boolean,
-                         private val canvas: Canvas = createCanvas(),
+                         private val canvas: Canvas = TerminalCanvas(),
                          private val swingTerminal: SwingTerminal =
                          SwingTerminal(
                                  canvas = canvas,
@@ -47,13 +48,18 @@ class SwingTerminalFrame(title: String = "ZirconTerminal",
         canvas.createBufferStrategy(2)
         swingTerminal.initializeBufferStrategy()
         addWindowStateListener(this)
+        TerminalCanvas::class.javaObjectType.cast(canvas).swingTerminal = swingTerminal
     }
 
     override fun close() {
         dispose()
     }
 
-    companion object {
-        private fun createCanvas() = Canvas()
+    private class TerminalCanvas() : Canvas() {
+        lateinit var swingTerminal: SwingTerminal
+
+        override fun paint (g: Graphics) {
+            swingTerminal.flush()
+        }
     }
 }


### PR DESCRIPTION
Fixes #77.

This creates a private `Canvas` subclass that invokes an `onPaint` callback.

This also removes `canvas.ignoreRepaint = true`.
I remember reading somewhere in the Swing docs (can't seem to find it now) that it recommended `canvas.setIgnoreRepaint(true)`, but I believe this is only necessary for real-time rendering.
I'm not sure how zircon handles animations, as this library is still new to me, but it definitely doesn't render in real-time when there are no animations playing, so repainting is needed on some platforms.

Edit: Do you know if there's any other importance to ignoring repaint?