### PR TITLE
Fix handleMouseMoved in DefaultComponentContainer

### DIFF
--- a/zircon.core/src/main/kotlin/org/hexworks/zircon/internal/component/impl/DefaultComponentContainer.kt
+++ b/zircon.core/src/main/kotlin/org/hexworks/zircon/internal/component/impl/DefaultComponentContainer.kt
@@ -182,9 +182,7 @@ class DefaultComponentContainer(private var container: DefaultContainer) :
             container.fetchComponentByPosition(lastMousePosition)
                     .map { currComponent ->
                         if (lastHoveredComponentId == currComponent.id) {
-                            if (lastFocusedComponent.id == currComponent.id) {
-                                EventBus.sendTo(currComponent.id, MouseMoved(mouseAction))
-                            }
+                            EventBus.sendTo(currComponent.id, MouseMoved(mouseAction))
                         } else {
                             EventBus.sendTo(lastHoveredComponentId, MouseOut(mouseAction))
                             lastHoveredComponentId = currComponent.id


### PR DESCRIPTION
Components were not getting the MOUSE_MOVED event due to a var never
being updated, but used in an if check. The check turned out to be
unnecessary, hence removed.