### PR TITLE
Fix bug when FadeIn used in StyleSet

### DIFF
--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/modifier/FadeIn.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/modifier/FadeIn.kt
@@ -11,7 +11,6 @@ data class FadeIn(private val steps: Int = 20,
     private var currentStep = 1
     private var delay: Long = timeMs / steps
     private var lastRender: Long = Long.MIN_VALUE
-    private lateinit var currentTile: CharacterTile
 
     override fun generateCacheKey(): String {
         return "Modifier.FadeIn.$currentStep"
@@ -22,7 +21,7 @@ data class FadeIn(private val steps: Int = 20,
     override fun transform(tile: CharacterTile): CharacterTile {
         if (isFirstRender()) {
             lastRender = SystemUtils.getCurrentTimeMs()
-            currentTile = generateTile(tile)
+            generateTile(tile)
         }
         return if (currentStep == steps) {
             if (glowOnFinalStep)
@@ -33,10 +32,9 @@ data class FadeIn(private val steps: Int = 20,
             val now = SystemUtils.getCurrentTimeMs()
             if (now - lastRender > delay) {
                 lastRender = now
-                currentTile = generateTile(tile)
                 currentStep++
             }
-            currentTile
+            generateTile(tile)
         }
     }
 

--- a/zircon.jvm.swing/src/test/kotlin/org/hexworks/zircon/internal/integration/IssueLabelFadeInExample.kt
+++ b/zircon.jvm.swing/src/test/kotlin/org/hexworks/zircon/internal/integration/IssueLabelFadeInExample.kt
@@ -1,0 +1,37 @@
+package org.hexworks.zircon.internal.integration
+
+import org.hexworks.zircon.api.*
+import org.hexworks.zircon.api.application.CursorStyle
+import org.hexworks.zircon.api.builder.component.ComponentStyleSetBuilder
+import org.hexworks.zircon.api.color.ANSITileColor
+import org.hexworks.zircon.api.data.Position
+import org.hexworks.zircon.api.modifier.FadeIn
+
+object IssueLabelFadeInExample {
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+
+        val tileGrid = SwingApplications.startTileGrid()
+
+        val screen = Screens.createScreenFor(tileGrid)
+        screen.display()
+
+
+        val styleSet = StyleSets.newBuilder()
+                .withForegroundColor(ANSITileColor.YELLOW)
+                .withModifiers(FadeIn(10, 1000, true))
+                .build()
+
+        val label = Components.label()
+                .withText("Fade In Label")
+                .withPosition(Position.create(1, 5))
+                .withComponentStyleSet(ComponentStyleSetBuilder
+                        .newBuilder()
+                        .withDefaultStyle(styleSet)
+                        .build())
+
+        screen.addComponent(label)
+    }
+
+}


### PR DESCRIPTION
Remove unnecessary state which caused the first tile to be repeated when FadeIn was used in a StyleSet