### PR TITLE
LibGDX Zircon: Loading textures correctly and fixed build.gradle

### DIFF
--- a/zircon.jvm.libgdx/build.gradle
+++ b/zircon.jvm.libgdx/build.gradle
@@ -19,6 +19,23 @@ dependencies {
     testCompile libraries.assertj
 }
 
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.kotlin
+}
+
+artifacts {
+    archives sourcesJar
+}
+
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "1.8"

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/renderer/LibgdxRenderer.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/renderer/LibgdxRenderer.kt
@@ -155,8 +155,9 @@ class LibgdxRenderer(private val grid: TileGrid,
         val x = position.x.toFloat()
         val y = position.y.toFloat()
         val backSprite = Sprite(backgroundTexture)
-        backSprite.setPosition(x, y)
         backSprite.setSize(backgroundWidth.toFloat(), backgroundHeight.toFloat())
+        backSprite.setOrigin(0f, 0f)
+        backSprite.setOriginBasedPosition(x, y)
         backSprite.color = Color(
                 tile.backgroundColor.red.toFloat() / 255,
                 tile.backgroundColor.green.toFloat() / 255,

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTileset.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTileset.kt
@@ -19,6 +19,7 @@ import org.hexworks.zircon.internal.tileset.impl.DefaultTileTexture
 import org.hexworks.zircon.internal.tileset.transformer.LibgdxTextureCloner
 import java.util.concurrent.TimeUnit
 import org.hexworks.zircon.internal.tileset.transformer.LibgdxTextureColorizer
+import org.hexworks.zircon.internal.util.Assets
 
 
 /**
@@ -43,12 +44,15 @@ class LibgdxTileset(override val width: Int,
             .build<String, TileTexture<TextureRegion>>()
 
     private val texture: Texture by lazy {
-        val bytes = Gdx.files.internal(path).readBytes()
-        val tex = Texture(Pixmap(bytes, 0, bytes.size))
-        if (!tex.textureData.isPrepared) {
-            tex.textureData.prepare()
+        if(!Assets.MANAGER.isLoaded(path)) {
+            Assets.MANAGER.load(Assets.getCP437TextureDescriptor(path))
         }
-        tex
+
+        while(!Assets.MANAGER.update()) {
+            //Loading...
+        }
+
+        Assets.MANAGER.get(Assets.getCP437TextureDescriptor(path))
     }
 
     override fun drawTile(tile: Tile, surface: SpriteBatch, position: Position) {

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTileset.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTileset.kt
@@ -59,7 +59,8 @@ class LibgdxTileset(override val width: Int,
         val x = position.x.toFloat()
         val y = position.y.toFloat()
         val tileSprite = Sprite(fetchTextureForTile(tile).texture)
-        tileSprite.setPosition(x, y)
+        tileSprite.setOrigin(0f, 0f)
+        tileSprite.setOriginBasedPosition(x, y)
         tileSprite.color = Color(
                 tile.foregroundColor.red.toFloat() / 255,
                 tile.foregroundColor.green.toFloat() / 255,

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTilesetLoader.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTilesetLoader.kt
@@ -34,7 +34,7 @@ class LibgdxTilesetLoader : TilesetLoader<SpriteBatch>, Closeable {
         private val LOADERS: Map<String, (TilesetResource) -> Tileset<SpriteBatch>> = mapOf(
                 "$CP437_TILESET-$CHARACTER_TILE" to { resource: TilesetResource ->
                     LibgdxTileset(
-                            path = "$fileHandlePrefix${resource.path}",
+                            path = resource.path,
                             width = resource.width,
                             height = resource.height
                     )

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/util/Assets.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/util/Assets.kt
@@ -1,0 +1,17 @@
+package org.hexworks.zircon.internal.util
+
+import com.badlogic.gdx.assets.AssetDescriptor
+import com.badlogic.gdx.assets.AssetManager
+import com.badlogic.gdx.graphics.Texture
+
+object Assets {
+    val MANAGER: AssetManager
+
+    init {
+        MANAGER = AssetManager()
+    }
+
+    fun getCP437TextureDescriptor(tilesetName: String) : AssetDescriptor<Texture> {
+        return AssetDescriptor<Texture>(tilesetName.substring(1), Texture::class.java)
+    }
+}

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/util/LibGDXTileGridFill.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/util/LibGDXTileGridFill.kt
@@ -3,7 +3,7 @@ import org.hexworks.zircon.api.component.Container
 import org.hexworks.zircon.api.data.Position
 import org.hexworks.zircon.api.data.Size
 
-private const val VERTICAL_HEIGHT_OFFSET = 1
+private const val VERTICAL_HEIGHT_OFFSET = 0
 
 fun gridFillByScreenSize(screenWidth: Int, screenHeight: Int, tileWidth: Int, tileHeight: Int) = Size.create(screenWidth / tileWidth, screenHeight / tileHeight - VERTICAL_HEIGHT_OFFSET)
 

--- a/zircon.jvm.libgdx/src/test/kotlin/org/hexworks/zircon/LibgdxPlayground.kt
+++ b/zircon.jvm.libgdx/src/test/kotlin/org/hexworks/zircon/LibgdxPlayground.kt
@@ -23,14 +23,16 @@ object LibgdxPlayground : Game() {
 
     private lateinit var zirconApplication: LibgdxApplication
 
-    private const val screenWidth = 1000
-    private const val screenHeight = 600
+    private const val screenWidth = 800
+    private const val screenHeight = 608
 
     override fun create() {
         logger.info("Creating LibgdxPlayground...")
         zirconApplication = LibgdxApplications.buildApplication(AppConfigs.newConfig()
                 .withDefaultTileset(TILESET)
-                .withSize(gridFillByScreenSize(screenWidth = screenWidth, screenHeight = screenHeight, tileWidth = TILESET.width, tileHeight = TILESET.height))
+                .withSize(Sizes.create(
+                        screenWidth / TILESET.width,
+                        screenHeight / TILESET.height))
                 .build())
         zirconApplication.start()
 
@@ -92,8 +94,8 @@ object LibgdxPlayground : Game() {
     fun main(args: Array<String>) {
         val config = LwjglApplicationConfiguration()
         config.title = "Zircon Playground"
-        config.width = 1000
-        config.height = 600
+        config.width = screenWidth
+        config.height = screenHeight
         config.foregroundFPS = 60
         config.useGL30 = true
         LwjglApplication(LibgdxPlayground, config)


### PR DESCRIPTION
This PR closes issues #167 #173 
Assets are loaded via the `AssetManager`, which provides a safer, less-volatile way to load the textures for rendering. This fixes #167 where the textures were not being found when using LibGDX Zircon in another project.
Publishing and SourceJar sections were added to the `build.gradle` of LibGDX Zircon, which allows the module to be correctly used in an outside project. This change in question solves #173 
This PR now also fixes the rendering of each tile and its backing being off by about 1/2 its height, which fixes the difference between the mouse position and selection of components.