### PR TITLE
Tiles render from top to bottom as opposed to the other way around

### DIFF
--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/renderer/LibgdxRenderer.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/renderer/LibgdxRenderer.kt
@@ -2,6 +2,7 @@ package org.hexworks.zircon.internal.renderer
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.graphics.Pixmap
 import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.graphics.g2d.Sprite
@@ -40,7 +41,11 @@ class LibgdxRenderer(private val grid: TileGrid,
     private var backgroundHeight: Int = 0
 
     override fun create() {
-        maybeBatch = Maybes.of(SpriteBatch())
+        maybeBatch = Maybes.of(SpriteBatch().apply {
+            val camera = OrthographicCamera()
+            camera.setToOrtho(true)
+            projectionMatrix = camera.combined
+        })
         cursorRenderer = ShapeRenderer()
         val whitePixmap = Pixmap(grid.widthInPixels, grid.heightInPixels, Pixmap.Format.RGBA8888)
         whitePixmap.setColor(Color.WHITE)
@@ -117,7 +122,7 @@ class LibgdxRenderer(private val grid: TileGrid,
                             tileset
                         }
 
-                val actualPos = Position.create((pos.x * actualTileset.width), (grid.height - pos.y - 1) * actualTileset.height)
+                val actualPos = Position.create(pos.x * actualTileset.width, pos.y * actualTileset.height)
                 drawBack(
                         tile = actualTile,
                         surface = batch,
@@ -141,7 +146,7 @@ class LibgdxRenderer(private val grid: TileGrid,
                             tileset
                         }
 
-                val actualPos = Position.create((pos.x * actualTileset.width), (grid.height - pos.y - 1) * actualTileset.height)
+                val actualPos = Position.create(pos.x * actualTileset.width, pos.y * actualTileset.height)
                 actualTileset.drawTile(
                         tile = actualTile,
                         surface = batch,
@@ -158,6 +163,7 @@ class LibgdxRenderer(private val grid: TileGrid,
         backSprite.setSize(backgroundWidth.toFloat(), backgroundHeight.toFloat())
         backSprite.setOrigin(0f, 0f)
         backSprite.setOriginBasedPosition(x, y)
+        backSprite.flip(false, true)
         backSprite.color = Color(
                 tile.backgroundColor.red.toFloat() / 255,
                 tile.backgroundColor.green.toFloat() / 255,

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTileset.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/tileset/LibgdxTileset.kt
@@ -61,6 +61,7 @@ class LibgdxTileset(override val width: Int,
         val tileSprite = Sprite(fetchTextureForTile(tile).texture)
         tileSprite.setOrigin(0f, 0f)
         tileSprite.setOriginBasedPosition(x, y)
+        tileSprite.flip(false, true)
         tileSprite.color = Color(
                 tile.foregroundColor.red.toFloat() / 255,
                 tile.foregroundColor.green.toFloat() / 255,

--- a/zircon.jvm.libgdx/src/test/kotlin/org/hexworks/zircon/LibgdxPlayground.kt
+++ b/zircon.jvm.libgdx/src/test/kotlin/org/hexworks/zircon/LibgdxPlayground.kt
@@ -24,7 +24,7 @@ object LibgdxPlayground : Game() {
     private lateinit var zirconApplication: LibgdxApplication
 
     private const val screenWidth = 800
-    private const val screenHeight = 608
+    private const val screenHeight = 600
 
     override fun create() {
         logger.info("Creating LibgdxPlayground...")
@@ -98,6 +98,7 @@ object LibgdxPlayground : Game() {
         config.height = screenHeight
         config.foregroundFPS = 60
         config.useGL30 = true
+        config.fullscreen = false
         LwjglApplication(LibgdxPlayground, config)
     }
 }


### PR DESCRIPTION
Fixes #177 
This PR renders the tiles starting at the top so that it is more in line with the Swing version and the input handling visually matches the rendering. This commit was co-authored by @wleroux 