### PR TITLE
Fix DEL handling in TextArea

### DIFF
--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/internal/component/impl/textedit/transformation/DeleteCharacter.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/internal/component/impl/textedit/transformation/DeleteCharacter.kt
@@ -41,7 +41,9 @@ class DeleteCharacter(private val deleteKind: DeleteKind) : TextBufferTransforma
                 when (deleteKind) {
                     DEL -> {
                         val deleteIdx = cursor.colIdx
-                        cursorRow.removeAt(deleteIdx)
+                        if (buffer.getLastColumnIdxForRow(cursor.rowIdx) >= deleteIdx) {
+                            cursorRow.removeAt(deleteIdx)
+                        }
                     }
                     BACKSPACE -> {
                         val deleteIdx = cursor.colIdx - 1


### PR DESCRIPTION
TextArea blew up if there was no character after the cursor AND the DEL
key was hit. There's now a bounds check in DeleteCharacter.kt which
prevents this issue.

Fixes #186