### PR TITLE
ToggleButtonBuilder ignores the value of isSelected() function

### DIFF
--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/behavior/Selectable.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/behavior/Selectable.kt
@@ -16,6 +16,6 @@ interface Selectable {
 
     companion object {
 
-        fun create(): Selectable = DefaultSelectable()
+        fun create(initialSelected: Boolean = false): Selectable = DefaultSelectable(initialSelected)
     }
 }

--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/builder/component/ToggleButtonBuilder.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/builder/component/ToggleButtonBuilder.kt
@@ -66,6 +66,7 @@ data class ToggleButtonBuilder(
                         componentStyleSet = componentStyleSet,
                         tileset = tileset),
                 initialText = text,
+                initialSelected = isSelected,
                 renderingStrategy = componentRenderer)
     }
 

--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/internal/behavior/impl/DefaultSelectable.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/internal/behavior/impl/DefaultSelectable.kt
@@ -3,8 +3,8 @@ package org.hexworks.zircon.internal.behavior.impl
 import org.hexworks.cobalt.databinding.api.createPropertyFrom
 import org.hexworks.zircon.api.behavior.Selectable
 
-class DefaultSelectable : Selectable {
+class DefaultSelectable(initialSelected: Boolean) : Selectable {
 
-    override val selectedProperty = createPropertyFrom(false)
+    override val selectedProperty = createPropertyFrom(initialSelected)
     override var isSelected: Boolean by selectedProperty.asDelegate()
 }

--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/internal/component/impl/DefaultToggleButton.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/internal/component/impl/DefaultToggleButton.kt
@@ -17,14 +17,20 @@ import org.hexworks.zircon.api.input.MouseAction
 
 class DefaultToggleButton(componentMetadata: ComponentMetadata,
                           initialText: String,
+                          initialSelected: Boolean,
                           private val renderingStrategy: ComponentRenderingStrategy<ToggleButton>)
     : ToggleButton, DefaultComponent(
         componentMetadata = componentMetadata,
         renderer = renderingStrategy),
         TextHolder by TextHolder.create(initialText),
-        Selectable by Selectable.create() {
+        Selectable by Selectable.create(initialSelected) {
 
     init {
+        // TODO: when the toggle button is selected by default (on create) it should be rendered as selected
+        // TODO: this if branch is supposed to do the trick, but it doesn't for some reason.
+        if (isSelected) {
+            applyIsSelectedStyle()
+        }
         render()
         textProperty.onChange {
             render()

--- a/zircon.core/jvm/src/test/kotlin/org/hexworks/zircon/internal/component/impl/DefaultToggleButtonTest.kt
+++ b/zircon.core/jvm/src/test/kotlin/org/hexworks/zircon/internal/component/impl/DefaultToggleButtonTest.kt
@@ -58,7 +58,8 @@ class DefaultToggleButtonTest : ComponentImplementationTest<DefaultToggleButton>
                 renderingStrategy = DefaultComponentRenderingStrategy(
                         decorationRenderers = listOf(),
                         componentRenderer = rendererStub as ComponentRenderer<ToggleButton>),
-                initialText = TEXT)
+                initialText = TEXT,
+                initialSelected = false)
     }
 
     @Test


### PR DESCRIPTION
The problem was that the builder did not pass its isSelected attribute
over to DefaultToggleButton. In order to make it possible Selectable and
DefaultSelectable had to be modified as well. They now work the same way
as (for example) TextHolder and DefaultTextHolder: Selectable.create()
accepts a boolean argument that is passed over to DefaultSelectable's
constructor which sets its isSelected accordingly through the
selectedProperty.

The fix brought up another problem: the component was not rendered
properly and it looked like as if it wasn't "selected", however, the
internal isSelected attribute held the correct value. A TODO is added to
the DefaultToggleButton where it is supposed to be solved.

Fixes #187