### PR TITLE
Fix issue #223: Component inside modal can't be the same size

### DIFF
--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/builder/component/ModalBuilder.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/builder/component/ModalBuilder.kt
@@ -55,7 +55,7 @@ data class ModalBuilder<T : ModalResult>(
             "Can't build a modal without a content component."
         }
         val component = contentComponent.get()
-        require(component.size < size) {
+        require(component.size <= size) {
             "Can't build a modal which has a component which is bigger than the modal."
         }
         if (centeredDialog) {


### PR DESCRIPTION
Fix [issue #223 ](https://github.com/Hexworks/zircon/issues/223) by adding the proper comparison operator