### PR TITLE
Fix isControlCharacter in TextUtils

### DIFF
--- a/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/util/TextUtils.kt
+++ b/zircon.core/common/src/main/kotlin/org/hexworks/zircon/api/util/TextUtils.kt
@@ -2,7 +2,7 @@ package org.hexworks.zircon.api.util
 
 object TextUtils {
 
-    fun isControlCharacter(c: Char) = c.toInt() < 32 || c.toInt() == 127
+    fun isControlCharacter(c: Char) = c.toInt() < 32 || c.toInt() >= 127
 
     fun isPrintableCharacter(c: Char) = !isControlCharacter(c)
 


### PR DESCRIPTION
While investigating issue #233, I noticed that the default TextArea implementation uses the isPrintableCharacter test to check if the pressed key is printable when no special cases are present. The problem is that there is no special case for the Shift key, so the function tries to determine if the char associated to shift is printable.

The isControlCharacter checks only against the 128 values that an ASCII char can take, but a Char in kotlin is 16bits, so any Char value higher than 126 is considered a printable character. This causes a problem when pressing shift, the char value associated is Char.MAX_VALUE and is considered a printable character and printed to the TextArea.

My fix simply considers any value equals to or higher than 127 to be a control character and therefore not a printable character