### PR TITLE
Modified LibGDX game system to fix compatibility with swing

### DIFF
--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/api/LibgdxApplications.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/api/LibgdxApplications.kt
@@ -1,6 +1,5 @@
 package org.hexworks.zircon.api
 
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration
 import org.hexworks.zircon.api.application.AppConfig
 import org.hexworks.zircon.api.application.Application
@@ -14,32 +13,56 @@ object LibgdxApplications {
      * Builds a new [Application] using the given `appConfig`.
      */
     @JvmStatic
-    fun buildApplication(appConfig: AppConfig = AppConfigs.defaultConfiguration()): LibgdxApplication {
-        return LibgdxApplication(appConfig)
+    @JvmOverloads
+    fun buildApplication(appConfig: AppConfig = AppConfigs.defaultConfiguration(),
+                         libgdxConfig: LwjglApplicationConfiguration = LwjglApplicationConfiguration()): LibgdxApplication {
+        return makeLibgdxGame(appConfig, libgdxConfig).libgdxApplication
     }
 
     /**
      * Builds and starts a new [Application] from the given `appConfig`.
      */
     @JvmStatic
-    fun startApplication(appConfig: AppConfig = AppConfigs.defaultConfiguration()): LibgdxApplication {
-        return startLibgdxGame(appConfig).libgdxApplication
+    @JvmOverloads
+    fun startApplication(appConfig: AppConfig = AppConfigs.defaultConfiguration(),
+                         libgdxConfig: LwjglApplicationConfiguration = LwjglApplicationConfiguration()): LibgdxApplication {
+        with(makeLibgdxGame(appConfig, libgdxConfig)) {
+            start()
+            return this.libgdxApplication
+        }
+    }
+
+    /**
+     * Builds JUST a new [Application], not a libgdx game
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun buildRawApplication(appConfig: AppConfig = AppConfigs.defaultConfiguration()): LibgdxApplication {
+        return LibgdxApplication(appConfig)
+    }
+
+    /**
+     * Starts JUST a new [Application], not a libgdx game
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun startRawApplication(appConfig: AppConfig = AppConfigs.defaultConfiguration()): LibgdxApplication {
+        return LibgdxApplication(appConfig).also {
+            it.start()
+        }
     }
 
     /**
      * Builds and starts a new [Application] and returns its [TileGrid].
      */
     @JvmStatic
-    fun startTileGrid(): TileGrid = startTileGrid(AppConfigs.defaultConfiguration())
-
-    /**
-     * Builds and starts a new [Application] and returns its [TileGrid].
-     */
-    @JvmStatic
-    fun startTileGrid(appConfig: AppConfig = AppConfigs.defaultConfiguration()): TileGrid {
+    @JvmOverloads
+    fun startTileGrid(appConfig: AppConfig = AppConfigs.defaultConfiguration(),
+                      libgdxConfig: LwjglApplicationConfiguration = LwjglApplicationConfiguration()): TileGrid {
         val maxTries = 10
         var currentTryCount = 0
-        val game = startLibgdxGame(appConfig)
+        val game = makeLibgdxGame(appConfig, libgdxConfig)
+        game.start()
         var notInitialized = true
         while (notInitialized) {
             try {
@@ -57,16 +80,21 @@ object LibgdxApplications {
         return game.libgdxApplication.tileGrid
     }
 
-    private fun startLibgdxGame(appConfig: AppConfig = AppConfigs.defaultConfiguration()): LibgdxGame {
-        val config = LwjglApplicationConfiguration()
-        config.title = appConfig.title
-        config.width = appConfig.size.width * appConfig.defaultTileset.width
-        config.height = appConfig.size.height * appConfig.defaultTileset.height
-        config.foregroundFPS = appConfig.fpsLimit
-        config.useGL30 = false
-        val game = LibgdxGame(appConfig)
-        LwjglApplication(game, config)
-        return game
+    /**
+     * Creates a [LibgdxGame] that contains a built and started [Application]
+     *
+     * Note that the Zircon `appConfig` fields title, size, and fpsLimit
+     * will override the Libgdx `LwjglApplicationConfiguration` fields
+     * title, width and height, and foregroundFPS respectively.
+     */
+    @JvmStatic
+    private fun makeLibgdxGame(appConfig: AppConfig = AppConfigs.defaultConfiguration(),
+                                libgdxConfig: LwjglApplicationConfiguration = LwjglApplicationConfiguration()): LibgdxGame {
+        libgdxConfig.title = appConfig.title
+        libgdxConfig.width = appConfig.size.width * appConfig.defaultTileset.width
+        libgdxConfig.height = appConfig.size.height * appConfig.defaultTileset.height
+        libgdxConfig.foregroundFPS = appConfig.fpsLimit
+        libgdxConfig.useGL30 = false
+        return LibgdxGame.build(appConfig, libgdxConfig)
     }
-
 }

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/application/LibgdxGame.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/application/LibgdxGame.kt
@@ -2,6 +2,8 @@ package org.hexworks.zircon.internal.application
 
 import com.badlogic.gdx.Game
 import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.backends.lwjgl.LwjglApplication
+import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration
 import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import org.hexworks.cobalt.logging.api.LoggerFactory
@@ -9,7 +11,9 @@ import org.hexworks.zircon.api.LibgdxApplications
 import org.hexworks.zircon.api.application.AppConfig
 import org.hexworks.zircon.internal.listeners.ZirconInputListener
 
-class LibgdxGame(private val appConfig: AppConfig) : Game() {
+class LibgdxGame(private val appConfig: AppConfig,
+                 private val libgdxConfig: LwjglApplicationConfiguration = LwjglApplicationConfiguration(),
+                 private var started: Boolean = false) : Game() {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -18,6 +22,13 @@ class LibgdxGame(private val appConfig: AppConfig) : Game() {
     private lateinit var batch: SpriteBatch
 
     lateinit var libgdxApplication: LibgdxApplication
+
+    fun start() {
+        if(!started) {
+            LwjglApplication(this, libgdxConfig)
+        }
+        started = true
+    }
 
     override fun create() {
         logger.info("Creating LibgdxGame...")
@@ -46,4 +57,13 @@ class LibgdxGame(private val appConfig: AppConfig) : Game() {
     override fun dispose() {
         batch.dispose()
     }
+
+    companion object {
+        fun build(appConfig: AppConfig = AppConfig.defaultConfiguration(),
+                  libgdxConfig: LwjglApplicationConfiguration = LwjglApplicationConfiguration()): LibgdxGame {
+            return LibgdxGame(appConfig, libgdxConfig)
+        }
+    }
+
+
 }

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/application/LibgdxGame.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/application/LibgdxGame.kt
@@ -21,7 +21,7 @@ class LibgdxGame(private val appConfig: AppConfig,
 
     private lateinit var batch: SpriteBatch
 
-    lateinit var libgdxApplication: LibgdxApplication
+    val libgdxApplication = LibgdxApplication(appConfig)
 
     fun start() {
         if(!started) {
@@ -36,7 +36,7 @@ class LibgdxGame(private val appConfig: AppConfig,
         batch = SpriteBatch()
         batch.enableBlending()
 
-        libgdxApplication = LibgdxApplications.buildApplication(appConfig)
+
         libgdxApplication.start()
         val tileGrid = libgdxApplication.tileGrid
 

--- a/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/renderer/LibgdxRenderer.kt
+++ b/zircon.jvm.libgdx/src/main/kotlin/org/hexworks/zircon/internal/renderer/LibgdxRenderer.kt
@@ -104,6 +104,10 @@ class LibgdxRenderer(private val grid: InternalTileGrid,
          * loop. I dare you. Have fun with the 14 fps, freak. I can't explain it, I
          * can only hope to save those that think they can optimize this. Leave it,
          * for your own sanity
+         *
+         * I think the problem resolved itself, magically. If this turns out to be not
+         * the case uncomment the commented block of code and delete the first
+         * actualTileset.drawTile()
          */
         state.tiles.forEach { (pos, tile) ->
             val actualPos = pos + state.position
@@ -128,9 +132,14 @@ class LibgdxRenderer(private val grid: InternalTileGrid,
                         surface = batch,
                         position = pixelPos
                 )
+                actualTileset.drawTile(
+                        tile = actualTile,
+                        surface = batch,
+                        position = pixelPos
+                )
             }
         }
-        state.tiles.forEach { (pos, tile) ->
+        /*state.tiles.forEach { (pos, tile) ->
             val actualPos = pos + state.position
             if (tile !== Tile.empty()) {
                 val actualTile =
@@ -153,7 +162,7 @@ class LibgdxRenderer(private val grid: InternalTileGrid,
                         position = pixelPos
                 )
             }
-        }
+        }*/
     }
 
     private fun drawBack(tile: Tile, surface: SpriteBatch, position: Position) {


### PR DESCRIPTION
Attempting to modify LibGDX game to work with the buildApplication() and startApplication() methods to provide the expected result when migrating from the Swing counterparts. Added buildRawApplication() and startRawApplication() for people who want to deal with the creation of the LibGDX game on their own. Fixes issue #222 