### PR TITLE
Let the Swing JFrame's layout manager decide on the size of the frame.

### DIFF
--- a/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/renderer/SwingCanvasRenderer.kt
+++ b/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/renderer/SwingCanvasRenderer.kt
@@ -57,11 +57,8 @@ class SwingCanvasRenderer(private val canvas: Canvas,
         if (config.fullScreen) {
             frame.extendedState = JFrame.MAXIMIZED_BOTH
             frame.isUndecorated = true
-        } else {
-            frame.setSize(tileGrid.widthInPixels, tileGrid.heightInPixels)
         }
 
-        frame.isVisible = true
         frame.isResizable = false
         frame.addWindowStateListener {
             if (it.newState == Frame.NORMAL) {
@@ -100,6 +97,7 @@ class SwingCanvasRenderer(private val canvas: Canvas,
             }
         })
         frame.pack()
+        frame.isVisible=true
         frame.setLocationRelativeTo(null)
 
         // buffering


### PR DESCRIPTION
This should fix the intermittent window size mismatch issue.