### PR TITLE
borderless window / simplified fullscreen #309

### DIFF
--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
@@ -24,6 +24,7 @@ data class AppConfig(
         val debugMode: Boolean,
         val size: Size,
         val fullScreen: Boolean,
+        val borderless: Boolean,
         val betaEnabled: Boolean,
         val title: String,
         val fpsLimit: Int,

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
@@ -28,6 +28,7 @@ data class AppConfigBuilder(
         private var defaultColorTheme: ColorTheme = ColorThemes.defaultTheme(),
         private var title: String = "Zircon Application",
         private var fullScreen: Boolean = false,
+        private var fullScreenSize: Size = Size.unknown(),
         private var borderless: Boolean = false,
         private var debugMode: Boolean = false,
         private var defaultSize: Size = Size.defaultGridSize(),
@@ -70,7 +71,13 @@ data class AppConfigBuilder(
     fun fullScreen() = also {
         fullScreen = true
         borderless = true
+    }
+
+    fun fullScreen(screenWidth: Int, screenHeight: Int) = also {
+        fullScreen = true
+        fullScreenSize = Size.create(screenWidth, screenHeight)
         defaultSize = Size.unknown()
+        borderless = true
     }
 
     fun borderless() = also {
@@ -148,8 +155,11 @@ data class AppConfigBuilder(
     }
 
     override fun build(): AppConfig {
-        if (fullScreen && defaultSize == Size.unknown()) {
-            TODO("calculate defaultSize from current screen resolution")
+        if (fullScreen && fullScreenSize != Size.unknown() && defaultSize == Size.unknown()) {
+            defaultSize = Size.create(
+                fullScreenSize.width / defaultTileset.width,
+                fullScreenSize.height / defaultTileset.height
+            )
         }
 
         return AppConfig(

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
@@ -28,6 +28,7 @@ data class AppConfigBuilder(
         private var defaultColorTheme: ColorTheme = ColorThemes.defaultTheme(),
         private var title: String = "Zircon Application",
         private var fullScreen: Boolean = false,
+        private var borderless: Boolean = false,
         private var debugMode: Boolean = false,
         private var defaultSize: Size = Size.defaultGridSize(),
         private var betaEnabled: Boolean = false,
@@ -68,6 +69,12 @@ data class AppConfigBuilder(
 
     fun fullScreen() = also {
         fullScreen = true
+        borderless = true
+        defaultSize = Size.unknown()
+    }
+
+    fun borderless() = also {
+        borderless = true
     }
 
     /**
@@ -140,7 +147,12 @@ data class AppConfigBuilder(
         this.betaEnabled = false
     }
 
-    override fun build() = AppConfig(
+    override fun build(): AppConfig {
+        if (fullScreen && defaultSize == Size.unknown()) {
+            TODO("calculate defaultSize from current screen resolution")
+        }
+
+        return AppConfig(
             blinkLengthInMilliSeconds = blinkLengthInMilliSeconds,
             cursorStyle = cursorStyle,
             cursorColor = cursorColor,
@@ -152,13 +164,15 @@ data class AppConfigBuilder(
             debugMode = debugMode,
             size = defaultSize,
             fullScreen = fullScreen,
+            borderless = borderless,
             betaEnabled = betaEnabled,
             title = title,
             fpsLimit = fpsLimit,
             debugConfig = debugConfig,
             closeBehavior = closeBehavior,
             shortcutsConfig = shortcutsConfig).also {
-        RuntimeConfig.config = it
+            RuntimeConfig.config = it
+        }
     }
 
     override fun createCopy() = copy()

--- a/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/BorderlessExample.java
+++ b/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/BorderlessExample.java
@@ -8,9 +8,13 @@ import java.awt.*;
 public class BorderlessExample {
 
     public static void main(String[] args) {
+        final Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+
         SwingApplications.startTileGrid(
             new AppConfigBuilder()
-                .borderless()
+//                .borderless()
+//                .fullScreen()
+                .fullScreen(screenSize.width, screenSize.height)
                 .build());
     }
 }

--- a/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/BorderlessExample.java
+++ b/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/BorderlessExample.java
@@ -1,0 +1,16 @@
+package org.hexworks.zircon.examples.game;
+
+import org.hexworks.zircon.api.SwingApplications;
+import org.hexworks.zircon.api.builder.application.AppConfigBuilder;
+
+import java.awt.*;
+
+public class BorderlessExample {
+
+    public static void main(String[] args) {
+        SwingApplications.startTileGrid(
+            new AppConfigBuilder()
+                .borderless()
+                .build());
+    }
+}

--- a/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/renderer/SwingCanvasRenderer.kt
+++ b/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/renderer/SwingCanvasRenderer.kt
@@ -56,6 +56,8 @@ class SwingCanvasRenderer(private val canvas: Canvas,
     override fun create() {
         if (config.fullScreen) {
             frame.extendedState = JFrame.MAXIMIZED_BOTH
+        }
+        if (config.borderless) {
             frame.isUndecorated = true
         }
 


### PR DESCRIPTION
introduce AppConfigBuilder.borderless()
this will create an undecorated window

currently there is tile grid size calculation open when you use just `AppConfigBuilder.fullscreen()`