### PR TITLE
Set application icon #297

### DIFF
--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
@@ -31,7 +31,7 @@ data class AppConfig(
         val debugConfig: DebugConfig,
         val closeBehavior: CloseBehavior,
         val shortcutsConfig: ShortcutsConfig,
-        val icon: String?
+        val icon: ByteArray?
 ) {
 
     companion object {

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
@@ -30,7 +30,8 @@ data class AppConfig(
         val fpsLimit: Int,
         val debugConfig: DebugConfig,
         val closeBehavior: CloseBehavior,
-        val shortcutsConfig: ShortcutsConfig
+        val shortcutsConfig: ShortcutsConfig,
+        val icon: String?
 ) {
 
     companion object {

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfig.kt
@@ -31,7 +31,8 @@ data class AppConfig(
         val debugConfig: DebugConfig,
         val closeBehavior: CloseBehavior,
         val shortcutsConfig: ShortcutsConfig,
-        val icon: ByteArray?
+        val iconData: ByteArray?,
+        val iconResource: String?
 ) {
 
     companion object {

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
@@ -36,7 +36,8 @@ data class AppConfigBuilder(
         private var fpsLimit: Int = 60,
         private var debugConfig: DebugConfig = DebugConfigBuilder.newBuilder().build(),
         private var closeBehavior: CloseBehavior = CloseBehavior.EXIT_ON_CLOSE,
-        private var shortcutsConfig: ShortcutsConfig = ShortcutsConfigBuilder.newBuilder().build())
+        private var shortcutsConfig: ShortcutsConfig = ShortcutsConfigBuilder.newBuilder().build(),
+        private var icon: String? = null)
     : Builder<AppConfig> {
 
     /**
@@ -154,6 +155,10 @@ data class AppConfigBuilder(
         this.betaEnabled = false
     }
 
+    fun withIcon(icon: String) = also {
+        this.icon = icon
+    }
+
     override fun build(): AppConfig {
         if (fullScreen && fullScreenSize != Size.unknown() && defaultSize == Size.unknown()) {
             defaultSize = Size.create(
@@ -180,7 +185,8 @@ data class AppConfigBuilder(
             fpsLimit = fpsLimit,
             debugConfig = debugConfig,
             closeBehavior = closeBehavior,
-            shortcutsConfig = shortcutsConfig).also {
+            shortcutsConfig = shortcutsConfig,
+            icon = icon).also {
             RuntimeConfig.config = it
         }
     }

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
@@ -37,7 +37,7 @@ data class AppConfigBuilder(
         private var debugConfig: DebugConfig = DebugConfigBuilder.newBuilder().build(),
         private var closeBehavior: CloseBehavior = CloseBehavior.EXIT_ON_CLOSE,
         private var shortcutsConfig: ShortcutsConfig = ShortcutsConfigBuilder.newBuilder().build(),
-        private var icon: String? = null)
+        private var icon: ByteArray? = null)
     : Builder<AppConfig> {
 
     /**
@@ -155,7 +155,7 @@ data class AppConfigBuilder(
         this.betaEnabled = false
     }
 
-    fun withIcon(icon: String) = also {
+    fun withIcon(icon: ByteArray) = also {
         this.icon = icon
     }
 

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
@@ -37,7 +37,8 @@ data class AppConfigBuilder(
         private var debugConfig: DebugConfig = DebugConfigBuilder.newBuilder().build(),
         private var closeBehavior: CloseBehavior = CloseBehavior.EXIT_ON_CLOSE,
         private var shortcutsConfig: ShortcutsConfig = ShortcutsConfigBuilder.newBuilder().build(),
-        private var icon: ByteArray? = null)
+        private var iconData: ByteArray? = null,
+        private var iconResource: String? = null)
     : Builder<AppConfig> {
 
     /**
@@ -155,8 +156,14 @@ data class AppConfigBuilder(
         this.betaEnabled = false
     }
 
-    fun withIcon(icon: ByteArray) = also {
-        this.icon = icon
+    fun withIcon(iconData: ByteArray) = also {
+        this.iconData = iconData
+        this.iconResource = null
+    }
+
+    fun withIcon(iconResource: String?) = also {
+        this.iconResource = iconResource
+        this.iconData = null
     }
 
     override fun build(): AppConfig {
@@ -186,7 +193,8 @@ data class AppConfigBuilder(
             debugConfig = debugConfig,
             closeBehavior = closeBehavior,
             shortcutsConfig = shortcutsConfig,
-            icon = icon).also {
+            iconData = iconData,
+            iconResource = iconResource).also {
             RuntimeConfig.config = it
         }
     }

--- a/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/IconExample.java
+++ b/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/IconExample.java
@@ -3,12 +3,28 @@ package org.hexworks.zircon.examples.game;
 import org.hexworks.zircon.api.SwingApplications;
 import org.hexworks.zircon.api.builder.application.AppConfigBuilder;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 public class IconExample {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         SwingApplications.startTileGrid(
             new AppConfigBuilder()
-                .withIcon("https://avatars0.githubusercontent.com/u/16441716?s=60&v=4")
+                .withIcon(loadIcon("/image_dictionary/hexworks_logo.png"))
                 .build());
+    }
+
+    private static byte[] loadIcon(final String path) throws IOException {
+        try (final InputStream inputStream = IconExample.class.getResourceAsStream(path)) {
+            final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            int nRead;
+            byte[] data = new byte[1024];
+            while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+            return buffer.toByteArray();
+        }
     }
 }

--- a/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/IconExample.java
+++ b/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/IconExample.java
@@ -1,0 +1,14 @@
+package org.hexworks.zircon.examples.game;
+
+import org.hexworks.zircon.api.SwingApplications;
+import org.hexworks.zircon.api.builder.application.AppConfigBuilder;
+
+public class IconExample {
+
+    public static void main(String[] args) {
+        SwingApplications.startTileGrid(
+            new AppConfigBuilder()
+                .withIcon("https://avatars0.githubusercontent.com/u/16441716?s=60&v=4")
+                .build());
+    }
+}

--- a/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/IconExample.java
+++ b/zircon.jvm.examples/src/main/java/org/hexworks/zircon/examples/game/IconExample.java
@@ -12,7 +12,8 @@ public class IconExample {
     public static void main(String[] args) throws IOException {
         SwingApplications.startTileGrid(
             new AppConfigBuilder()
-                .withIcon(loadIcon("/image_dictionary/hexworks_logo.png"))
+//                .withIcon(loadIcon("/image_dictionary/hexworks_logo.png"))
+                .withIcon("image_dictionary/hexworks_logo.png")
                 .build());
     }
 

--- a/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/impl/SwingFrame.kt
+++ b/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/impl/SwingFrame.kt
@@ -16,8 +16,11 @@ class SwingFrame(val tileGrid: InternalTileGrid,
 
     init {
         title = config.title
-        if (config.icon != null) {
-            ByteArrayInputStream(config.icon)
+        if (config.iconData != null) {
+            ByteArrayInputStream(config.iconData)
+                .use { inputStream -> iconImage = ImageIO.read(inputStream) }
+        } else if (config.iconResource != null) {
+            ClassLoader.getSystemResourceAsStream(config.iconResource)
                 .use { inputStream -> iconImage = ImageIO.read(inputStream) }
         }
         add(canvas)

--- a/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/impl/SwingFrame.kt
+++ b/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/impl/SwingFrame.kt
@@ -5,6 +5,9 @@ import org.hexworks.zircon.api.application.Application
 import org.hexworks.zircon.internal.grid.InternalTileGrid
 import org.hexworks.zircon.internal.renderer.SwingCanvasRenderer
 import java.awt.Canvas
+import java.io.IOException
+import java.net.URL
+import javax.imageio.ImageIO
 import javax.swing.JFrame
 
 class SwingFrame(val tileGrid: InternalTileGrid,
@@ -14,6 +17,13 @@ class SwingFrame(val tileGrid: InternalTileGrid,
 
     init {
         title = config.title
+        if (config.icon != null) {
+            try {
+                iconImage = ImageIO.read(URL(config.icon))
+            } catch (exception: IOException) {
+                // unable to load icon image
+            }
+        }
         add(canvas)
     }
 

--- a/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/impl/SwingFrame.kt
+++ b/zircon.jvm.swing/src/main/kotlin/org/hexworks/zircon/internal/impl/SwingFrame.kt
@@ -5,8 +5,7 @@ import org.hexworks.zircon.api.application.Application
 import org.hexworks.zircon.internal.grid.InternalTileGrid
 import org.hexworks.zircon.internal.renderer.SwingCanvasRenderer
 import java.awt.Canvas
-import java.io.IOException
-import java.net.URL
+import java.io.ByteArrayInputStream
 import javax.imageio.ImageIO
 import javax.swing.JFrame
 
@@ -18,11 +17,8 @@ class SwingFrame(val tileGrid: InternalTileGrid,
     init {
         title = config.title
         if (config.icon != null) {
-            try {
-                iconImage = ImageIO.read(URL(config.icon))
-            } catch (exception: IOException) {
-                // unable to load icon image
-            }
+            ByteArrayInputStream(config.icon)
+                .use { inputStream -> iconImage = ImageIO.read(inputStream) }
         }
         add(canvas)
     }


### PR DESCRIPTION
extend app builder to enable caller to customize applications icon

AppConfig and AppConfiguBuilder now include a null-able string for icon. String has to contain a valid URL to a image. Conversion and loading is done in SwingApplication. Currently I do not like to represent icons URL as string.