### PR TITLE
Checkbox improvements

### DIFF
--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/component/CheckBoxBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/component/CheckBoxBuilder.kt
@@ -1,7 +1,6 @@
 package org.hexworks.zircon.api.builder.component
 
 import org.hexworks.zircon.api.component.CheckBox
-import org.hexworks.zircon.api.component.ComponentAlignment
 import org.hexworks.zircon.api.component.builder.base.BaseComponentBuilder
 import org.hexworks.zircon.api.component.data.ComponentMetadata
 import org.hexworks.zircon.api.component.renderer.ComponentRenderer

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/component/CheckBoxBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/component/CheckBoxBuilder.kt
@@ -1,10 +1,13 @@
 package org.hexworks.zircon.api.builder.component
 
 import org.hexworks.zircon.api.component.CheckBox
+import org.hexworks.zircon.api.component.ComponentAlignment
 import org.hexworks.zircon.api.component.builder.base.BaseComponentBuilder
 import org.hexworks.zircon.api.component.data.ComponentMetadata
 import org.hexworks.zircon.api.component.renderer.ComponentRenderer
+import org.hexworks.zircon.api.data.Size
 import org.hexworks.zircon.internal.component.impl.DefaultCheckBox
+import org.hexworks.zircon.internal.component.impl.DefaultCheckBox.CheckBoxAlignment
 import org.hexworks.zircon.internal.component.renderer.DefaultCheckBoxRenderer
 import org.hexworks.zircon.internal.component.renderer.DefaultComponentRenderingStrategy
 import kotlin.jvm.JvmStatic
@@ -12,13 +15,23 @@ import kotlin.math.max
 
 @Suppress("UNCHECKED_CAST")
 class CheckBoxBuilder(
-        private var text: String = "")
+        private var text: String = "",
+        private var labelAlignment: CheckBoxAlignment = CheckBoxAlignment.RIGHT)
     : BaseComponentBuilder<CheckBox, CheckBoxBuilder>(DefaultCheckBoxRenderer()) {
 
     fun withText(text: String) = also {
         this.text = text
+        val totalSize =
+                if (text == "")
+                    DefaultCheckBoxRenderer.BUTTON_WIDTH
+                else
+                    text.length + DefaultCheckBoxRenderer.DECORATION_WIDTH
         contentSize = contentSize
-                .withWidth(max(text.length + DefaultCheckBoxRenderer.DECORATION_WIDTH, contentSize.width))
+                .withWidth(max(totalSize, contentSize.width))
+    }
+
+    fun withLeftAlignedText() = also {
+        labelAlignment = CheckBoxAlignment.LEFT
     }
 
     override fun build(): CheckBox {
@@ -29,6 +42,7 @@ class CheckBoxBuilder(
                         componentStyleSet = componentStyleSet,
                         tileset = tileset),
                 initialText = text,
+                labelAlignment = labelAlignment,
                 renderingStrategy = DefaultComponentRenderingStrategy(
                         decorationRenderers = decorationRenderers,
                         componentRenderer = componentRenderer as ComponentRenderer<CheckBox>)).apply {
@@ -44,6 +58,6 @@ class CheckBoxBuilder(
     companion object {
 
         @JvmStatic
-        fun newBuilder() = CheckBoxBuilder()
+        fun newBuilder() = CheckBoxBuilder().apply { contentSize = Size.create(DefaultCheckBoxRenderer.BUTTON_WIDTH,1) }
     }
 }

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/component/CheckBoxBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/component/CheckBoxBuilder.kt
@@ -18,6 +18,10 @@ class CheckBoxBuilder(
         private var labelAlignment: CheckBoxAlignment = CheckBoxAlignment.RIGHT)
     : BaseComponentBuilder<CheckBox, CheckBoxBuilder>(DefaultCheckBoxRenderer()) {
 
+    init {
+        contentSize = Size.create(DefaultCheckBoxRenderer.BUTTON_WIDTH,1)
+    }
+
     fun withText(text: String) = also {
         this.text = text
         val totalSize =
@@ -57,6 +61,6 @@ class CheckBoxBuilder(
     companion object {
 
         @JvmStatic
-        fun newBuilder() = CheckBoxBuilder().apply { contentSize = Size.create(DefaultCheckBoxRenderer.BUTTON_WIDTH,1) }
+        fun newBuilder() = CheckBoxBuilder()
     }
 }

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/component/CheckBox.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/component/CheckBox.kt
@@ -3,9 +3,10 @@ package org.hexworks.zircon.api.component
 import org.hexworks.zircon.api.behavior.Selectable
 import org.hexworks.zircon.api.behavior.TextHolder
 import org.hexworks.zircon.internal.component.impl.DefaultCheckBox.CheckBoxState
+import org.hexworks.zircon.internal.component.impl.DefaultCheckBox.CheckBoxAlignment
 
 interface CheckBox : Component, Selectable, TextHolder {
 
     val checkBoxState: CheckBoxState
-
+    val labelAlignment: CheckBoxAlignment
 }

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/impl/DefaultCheckBox.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/impl/DefaultCheckBox.kt
@@ -20,6 +20,7 @@ import kotlin.jvm.Synchronized
 class DefaultCheckBox(
         componentMetadata: ComponentMetadata,
         initialText: String,
+        override val labelAlignment: CheckBoxAlignment,
         renderingStrategy: ComponentRenderingStrategy<CheckBox>
 ) : CheckBox, DefaultComponent(
         componentMetadata = componentMetadata,
@@ -75,5 +76,10 @@ class DefaultCheckBox(
         CHECKED,
         UNCHECKING,
         UNCHECKED
+    }
+
+    enum class CheckBoxAlignment {
+        LEFT,
+        RIGHT
     }
 }

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/impl/DefaultCheckBox.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/impl/DefaultCheckBox.kt
@@ -20,7 +20,7 @@ import kotlin.jvm.Synchronized
 class DefaultCheckBox(
         componentMetadata: ComponentMetadata,
         initialText: String,
-        override val labelAlignment: CheckBoxAlignment,
+        override val labelAlignment: CheckBoxAlignment = CheckBoxAlignment.RIGHT,
         renderingStrategy: ComponentRenderingStrategy<CheckBox>
 ) : CheckBox, DefaultComponent(
         componentMetadata = componentMetadata,

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/renderer/DefaultCheckBoxRenderer.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/renderer/DefaultCheckBoxRenderer.kt
@@ -15,14 +15,27 @@ class DefaultCheckBoxRenderer : ComponentRenderer<DefaultCheckBox> {
     override fun render(tileGraphics: TileGraphics, context: ComponentRenderContext<DefaultCheckBox>) {
         val state = context.component.checkBoxState
         val text = context.component.text
-        val maxTextLength = tileGraphics.size.width - DECORATION_WIDTH
-        val clearedText = if (text.length > maxTextLength) {
-            text.substring(0, maxTextLength - 3).plus(ELLIPSIS)
-        } else {
-            text
-        }
+        val labelAlignment = context.component.labelAlignment
+
+        val checkBox = STATES.getValue(state)
+        val checkBoxWithLabel =
+                if (text == "") checkBox
+                else {
+                    val maxTextLength = tileGraphics.size.width - DECORATION_WIDTH
+                    val clearedText =
+                            if (text.length > maxTextLength) {
+                                text.substring(0, maxTextLength - 3).plus(ELLIPSIS)
+                            } else {
+                                text
+                            }
+                    when (labelAlignment) {
+                        DefaultCheckBox.CheckBoxAlignment.LEFT -> "$clearedText $checkBox"
+                        DefaultCheckBox.CheckBoxAlignment.RIGHT -> "$checkBox $clearedText"
+                    }
+                }
+
         tileGraphics.fillWithText(
-                text = "${STATES.getValue(state)} $clearedText",
+                text = checkBoxWithLabel,
                 style = context.currentStyle)
     }
 
@@ -32,8 +45,8 @@ class DefaultCheckBoxRenderer : ComponentRenderer<DefaultCheckBox> {
         private const val UNCHECKING_BUTTON = "[-]"
         private const val CHECKED_BUTTON = "[*]"
         private const val UNCHECKED_BUTTON = "[ ]"
-        private const val BUTTON_WIDTH = CHECKING_BUTTON.length
 
+        const val BUTTON_WIDTH = CHECKING_BUTTON.length
         const val DECORATION_WIDTH = BUTTON_WIDTH + 1
 
         private val STATES = mapOf(


### PR DESCRIPTION
Implements #332:

* Fixes the 4 wide checkbox when no text is added

![no-more-bleeding](https://user-images.githubusercontent.com/3763769/97092938-39510700-1648-11eb-8011-3f702f001a9b.png)

* Fixes a bug where not adding text to the checkbox would cause it to not render correctly
* Adds `withLeftAlignedText()` to the CheckBoxBuilder 

![left-aligned](https://user-images.githubusercontent.com/3763769/97092931-32c28f80-1648-11eb-8263-7e53e7d8aa84.png)
