### PR TITLE
Implement docs generation in "Kotlin as Java" format, extract Dokka version to properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
-@file:Suppress("UnstableApiUsage")
-
-import java.lang.StringBuilder
+import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
+import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
-    id("org.jetbrains.dokka") version "1.4.10.2"
+    id("org.jetbrains.dokka")
 }
 
 allprojects {
@@ -15,29 +14,48 @@ allprojects {
     }
 }
 
-tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.set(projectDir.resolve("docs").resolve(project.version.toString()))
-}
+tasks {
+    val docsDir = projectDir.resolve("docs")
 
-tasks.dokkaHtmlMultiModule {
-    doLast {
-        println("---=== Generating index.html for docs ===---")
-        val docs = File("docs")
-        val html = StringBuilder()
-        html.append("<html><head><title>Choose a Version</title></head><body>")
-        html.append("<h1>Pick a Version</h1><ul>")
-        docs.listFiles()
-                ?.filter { it.name.contains("index.html").not() }
-                ?.filter { it.isDirectory }
-                ?.forEach { dir ->
-                    html.append("<li><a href=\"${dir.name}\">${dir.name}</a></li>")
-                }
-        html.append("</ul></body></html>")
-        File("docs/index.html").apply {
-            if (exists()) {
-                delete()
-            }
-            writeText(html.toString())
+    val renameModulesToIndex by registering {
+        doLast {
+            logger.lifecycle("---=== Renaming -modules.html to index.html ===---")
+            docsDir.listFiles()
+                    ?.filter { it.isDirectory }
+                    ?.forEach { dir ->
+                        dir.listFiles()
+                                ?.find { file -> file.name == "-modules.html" }
+                                ?.renameTo(File(dir, "index.html"))
+                    }
         }
+    }
+
+    val generateDocsIndexTask by registering {
+        doLast {
+            logger.lifecycle("---=== Generating index.html for docs ===---")
+
+            val docsSubDirs = docsDir.listFiles()
+                    ?.filter { it.isDirectory }
+                    ?.joinToString("\n") { dir -> "<li><a href=\"${dir.name}\">${dir.name}</a></li>" }
+
+            val html = """|<!doctype html><head><title>Choose a Version</title></head><body>
+                |<h1>Pick a Version</h1><ul>
+                |$docsSubDirs
+                |</ul></body></html>""".trimMargin()
+
+            docsDir.resolve("index.html").writeText(html)
+        }
+    }
+
+    dokkaHtmlMultiModule {
+        outputDirectory.set(docsDir.resolve(project.version.toString()))
+        finalizedBy(renameModulesToIndex, generateDocsIndexTask)
+    }
+
+    register<DokkaMultiModuleTask>("dokkaHtmlAsJavaMultiModule") {
+        addSubprojectChildTasks("dokkaHtmlAsJava")
+        removeChildTask(":zircon.core:dokkaHtmlAsJava") // TODO: remove after https://github.com/Kotlin/dokka/issues/1663 is fixed
+        outputDirectory.set(docsDir.resolve("${project.version}-JAVA"))
+        finalizedBy(renameModulesToIndex, generateDocsIndexTask)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=1g
 org.gradle.configureondemand=true
 
+dokka_version=1.4.20
+
 POM_PACKAGING=jar
 POM_URL=https://github.com/Hexworks/zircon
 POM_SCM_URL=https://github.com/Hexworks/zircon.git

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,16 @@
 enableFeaturePreview("GRADLE_METADATA")
 
+pluginManagement {
+    resolutionStrategy {
+        val dokka_version: String by settings
+        eachPlugin {
+            if (requested.id.id == "org.jetbrains.dokka") {
+                useModule("org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version")
+            }
+        }
+    }
+}
+
 rootProject.name = "zircon"
 
 include(":zircon.core")

--- a/zircon.core/build.gradle.kts
+++ b/zircon.core/build.gradle.kts
@@ -76,30 +76,31 @@ kotlin {
 
 }
 
-tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets {
-        configureEach {
-            includeNonPublic.set(false)
-            skipDeprecated.set(false)
-            skipEmptyPackages.set(true)
-            includes.from("module.md", "packages.md")
+tasks {
+    create<DokkaTask>("dokkaHtmlAsJava") {
+        val dokka_version: String by project
+        dependencies {
+            plugins("org.jetbrains.dokka:kotlin-as-java-plugin:$dokka_version")
+        }
+    }
 
-            samples.from("src/commonMain/kotlin/org/hexworks/zircon/samples")
+    withType<DokkaTask>().configureEach {
+        dokkaSourceSets {
+            configureEach {
+                includes.from("module.md", "packages.md")
+                samples.from("src/commonMain/kotlin/org/hexworks/zircon/samples")
 
-            sourceLink {
-                localDirectory.set(file("src/commonMain/kotlin"))
-                remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.core/src/commonMain/kotlin"))
-                remoteLineSuffix.set("#L")
+                sourceLink {
+                    localDirectory.set(file("src/commonMain/kotlin"))
+                    remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.core/src/commonMain/kotlin"))
+                }
+
+                sourceLink {
+                    localDirectory.set(file("src/jvmMain/kotlin"))
+                    remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.core/src/jvmMain/kotlin"))
+                }
+                jdkVersion.set(8)
             }
-            sourceLink {
-                localDirectory.set(file("src/jvmMain/kotlin"))
-                remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.core/src/jvmMain/kotlin"))
-                remoteLineSuffix.set("#L")
-            }
-            jdkVersion.set(8)
-            noStdlibLink.set(false)
-            noJdkLink.set(false)
-            noAndroidSdkLink.set(false)
         }
     }
 }

--- a/zircon.jvm.examples/build.gradle.kts
+++ b/zircon.jvm.examples/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 base.archivesBaseName = "zircon.jvm.examples"
 
 application {
-    mainClassName = "org.hexworks.zircon.benchmark.SwingBenchmark"
+    mainClass.set("org.hexworks.zircon.benchmark.SwingBenchmark")
 }
 
 kotlin {
@@ -22,7 +22,7 @@ kotlin {
             api("org.openjdk.jol:jol-core:0.13")
         }
 
-        with (Libs) {
+        with(Libs) {
             api(gdx)
             api(gdxFreetype)
             api(gdxFreetypePlatform)

--- a/zircon.jvm.libgdx/build.gradle.kts
+++ b/zircon.jvm.libgdx/build.gradle.kts
@@ -46,22 +46,24 @@ kotlin {
     }
 }
 
-tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets {
-        configureEach {
-            includeNonPublic.set(false)
-            skipDeprecated.set(false)
-            skipEmptyPackages.set(true)
-            includes.from("module.md", "packages.md")
-            sourceLink {
-                localDirectory.set(file("src/main/kotlin"))
-                remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.jvm.libgdx/src/main/kotlin"))
-                remoteLineSuffix.set("#L")
+tasks {
+    create<DokkaTask>("dokkaHtmlAsJava") {
+        val dokka_version: String by project
+        dependencies {
+            plugins("org.jetbrains.dokka:kotlin-as-java-plugin:$dokka_version")
+        }
+    }
+
+    withType<DokkaTask>().configureEach {
+        dokkaSourceSets {
+            configureEach {
+                includes.from("module.md", "packages.md")
+                sourceLink {
+                    localDirectory.set(file("src/main/kotlin"))
+                    remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.jvm.libgdx/src/main/kotlin"))
+                }
+                jdkVersion.set(8)
             }
-            jdkVersion.set(8)
-            noStdlibLink.set(false)
-            noJdkLink.set(false)
-            noAndroidSdkLink.set(false)
         }
     }
 }

--- a/zircon.jvm.swing/build.gradle.kts
+++ b/zircon.jvm.swing/build.gradle.kts
@@ -36,22 +36,24 @@ kotlin {
     }
 }
 
-tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
-    dokkaSourceSets {
-        configureEach {
-            includeNonPublic.set(false)
-            skipDeprecated.set(false)
-            skipEmptyPackages.set(true)
-            includes.from("module.md", "packages.md")
-            sourceLink {
-                localDirectory.set(file("src/main/kotlin"))
-                remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.jvm.swing/src/main/kotlin"))
-                remoteLineSuffix.set("#L")
+tasks {
+    create<org.jetbrains.dokka.gradle.DokkaTask>("dokkaHtmlAsJava") {
+        val dokka_version: String by project
+        dependencies {
+            plugins("org.jetbrains.dokka:kotlin-as-java-plugin:$dokka_version")
+        }
+    }
+
+    withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
+        dokkaSourceSets {
+            configureEach {
+                includes.from("module.md", "packages.md")
+                sourceLink {
+                    localDirectory.set(file("src/main/kotlin"))
+                    remoteUrl.set(URL("https://github.com/Hexworks/zircon/tree/master/zircon.jvm.swing/src/main/kotlin"))
+                }
+                jdkVersion.set(8)
             }
-            jdkVersion.set(8)
-            noStdlibLink.set(false)
-            noJdkLink.set(false)
-            noAndroidSdkLink.set(false)
         }
     }
 }


### PR DESCRIPTION
* The `pluginManagement` block is debatable, however that's probably the easiest way to ensure the version compatibility between Dokka and Dokka's plugins (a slightly worse way would be to use a `buildscript` block)
* The `-modules.html` renaming task probably won't be needed after `1.4.20.2` version
* Unfortunately `kotlinAsJava` format crashes for the `:zircon.core` subproject, please observe https://github.com/Kotlin/dokka/issues/1663 for a fix 