### PR TITLE
Update headers to wrap on word, plus test extension functions

### DIFF
--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/renderer/DefaultHeaderRenderer.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/component/renderer/DefaultHeaderRenderer.kt
@@ -2,12 +2,13 @@ package org.hexworks.zircon.internal.component.renderer
 
 import org.hexworks.zircon.api.component.renderer.ComponentRenderContext
 import org.hexworks.zircon.api.component.renderer.ComponentRenderer
+import org.hexworks.zircon.api.graphics.TextWrap.WORD_WRAP
 import org.hexworks.zircon.api.graphics.TileGraphics
 import org.hexworks.zircon.internal.component.impl.DefaultHeader
 
 class DefaultHeaderRenderer : ComponentRenderer<DefaultHeader> {
 
     override fun render(tileGraphics: TileGraphics, context: ComponentRenderContext<DefaultHeader>) {
-        tileGraphics.fillWithText(context.component.text, context.currentStyle)
+        tileGraphics.fillWithText(context.component.text, context.currentStyle, textWrap = WORD_WRAP)
     }
 }

--- a/zircon.core/src/commonTest/kotlin/org/hexworks/zircon/CharacterTilesAsString.kt
+++ b/zircon.core/src/commonTest/kotlin/org/hexworks/zircon/CharacterTilesAsString.kt
@@ -1,0 +1,30 @@
+package org.hexworks.zircon
+
+import org.hexworks.zircon.api.data.CharacterTile
+import org.hexworks.zircon.api.data.Size
+import org.hexworks.zircon.api.graphics.TileComposite
+
+/**
+ * Converts a collection of character tiles (usually found at [TileComposite.tiles]) into a string.
+ */
+fun TileComposite.convertCharacterTilesToString(padToSize: Size = Size.zero()): String {
+    val strings = mutableListOf<StringBuilder>()
+    while (strings.size < padToSize.height) {
+        val sb = StringBuilder().also { sb -> repeat(padToSize.width) { sb.append(' ') } }
+        strings.add(sb)
+    }
+
+    for ((position, tile) in this.tiles) {
+        val (x, y) = position
+        while (y >= strings.size) {
+            strings.add(StringBuilder())
+        }
+        val sb = strings[y]
+        while (sb.length <= x || sb.length < padToSize.width) {
+            sb.append(' ');
+        }
+
+        sb.setCharAt(x, (tile as CharacterTile).character)
+    }
+    return strings.joinToString(separator = "\n") { it.toString() }
+}

--- a/zircon.core/src/commonTest/kotlin/org/hexworks/zircon/CharacterTilesAsStringTest.kt
+++ b/zircon.core/src/commonTest/kotlin/org/hexworks/zircon/CharacterTilesAsStringTest.kt
@@ -1,0 +1,126 @@
+package org.hexworks.zircon
+
+import org.hexworks.zircon.api.data.Position
+import org.hexworks.zircon.api.data.Size
+import org.hexworks.zircon.api.data.Tile
+import org.hexworks.zircon.internal.graphics.DefaultTileComposite
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CharacterTilesAsStringTest {
+    private fun pos(x: Int, y: Int) = Position.create(x, y)
+    private fun charTile(char: Char) = Tile.newBuilder().withCharacter(char).buildCharacterTile()
+
+    private fun tileComposite(tiles: Map<Position, Tile>, size: Size = Size.zero()) = DefaultTileComposite(tiles, size)
+
+    @Test
+    fun empty() {
+        assertTrue("is empty") { tileComposite(emptyMap()).convertCharacterTilesToString().isEmpty() }
+    }
+
+    @Test
+    fun simple() {
+        assertEquals(".", tileComposite(mapOf(pos(0, 0) to charTile('.'))).convertCharacterTilesToString())
+    }
+
+    @Test
+    fun leadingSpaces() {
+        assertEquals(
+            "   .", tileComposite(
+                mapOf<Position, Tile>(
+                    pos(3, 0) to charTile('.')
+                )
+            ).convertCharacterTilesToString()
+        )
+    }
+
+    @Test
+    fun multipleLines() {
+        assertEquals(
+            """
+                .
+                !
+            """.trimIndent(), tileComposite(
+                mapOf<Position, Tile>(
+                    pos(0, 0) to charTile('.'),
+                    pos(0, 1) to charTile('!')
+                )
+            ).convertCharacterTilesToString()
+        )
+    }
+
+    @Test
+    fun skippedLine() {
+        assertEquals(
+            """
+                
+                !
+            """.trimIndent(),
+            tileComposite(
+                mapOf<Position, Tile>(
+                    pos(0, 1) to charTile('!')
+                )
+            ).convertCharacterTilesToString()
+        )
+    }
+
+    @Test
+    fun padToWidth() {
+        assertEquals(
+            "  .  ",
+            tileComposite(
+                mapOf(
+                    pos(2, 0) to charTile('.')
+                )
+            ).convertCharacterTilesToString(padToSize = Size.create(5, 0))
+        )
+    }
+
+    @Test
+    fun padToHeight() {
+        assertEquals(
+            ".\n",
+            tileComposite(
+                mapOf(
+                    pos(0, 0) to charTile('.')
+                )
+            ).convertCharacterTilesToString(padToSize = Size.create(0, 2))
+        )
+    }
+
+    @Test
+    fun padToSize() {
+        assertEquals(
+            "   \n . \n   ",
+            tileComposite(
+                mapOf(
+                    pos(1, 1) to charTile('.')
+                )
+            ).convertCharacterTilesToString(padToSize = Size.create(3, 3))
+        )
+    }
+
+    @Test
+    fun words() {
+        assertEquals(
+            """
+                hi to
+                
+                you
+            """.trimIndent(),
+            tileComposite(
+                mapOf<Position, Tile>(
+                    pos(0, 2) to charTile('y'),
+                    pos(1, 2) to charTile('o'),
+                    pos(2, 2) to charTile('u'),
+                    pos(0, 0) to charTile('h'),
+                    pos(1, 0) to charTile('i'),
+                    pos(2, 0) to charTile(' '),
+                    pos(3, 0) to charTile('t'),
+                    pos(4, 0) to charTile('o')
+                )
+            ).convertCharacterTilesToString()
+        )
+    }
+}

--- a/zircon.core/src/commonTest/kotlin/org/hexworks/zircon/TestFunctions.kt
+++ b/zircon.core/src/commonTest/kotlin/org/hexworks/zircon/TestFunctions.kt
@@ -7,3 +7,10 @@ fun TileComposite.fetchCharacters(): List<Char> {
         getTileAt(it).get().asCharacterTile().get().character
     }
 }
+
+/**
+ * Ensure each line is at least [length] long, padding it with [padChar] if it's not. This splits the string on newline
+ * internally and uses [lineSeparator] to re-join the lines.
+ */
+fun String.padLineEnd(length: Int, padChar: Char = ' ', lineSeparator: String = "\n"): String =
+    lineSequence().joinToString(lineSeparator) { it.padEnd(length, padChar) }

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/CommonComponentTest.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/CommonComponentTest.kt
@@ -40,6 +40,7 @@ abstract class CommonComponentTest<T : InternalComponent> {
     val POSITION_2_3 = Position.create(2, 3)
     val POSITION_1_1 = Position.create(1, 1)
     val SIZE_3_4 = Size.create(3, 4)
+    val SIZE_10_4 = Size.create(10, 4)
     val TILESET_REX_PAINT_20X20 = CP437TilesetResources.rexPaint20x20()
     val COMPONENT_STYLES = ComponentStyleSet.defaultStyleSet()
     val COMMON_COMPONENT_METADATA = ComponentMetadata(

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/DefaultHeaderTest.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/DefaultHeaderTest.kt
@@ -15,6 +15,7 @@ import org.hexworks.zircon.api.uievent.Pass
 import org.hexworks.zircon.convertCharacterTilesToString
 import org.hexworks.zircon.internal.component.renderer.DefaultComponentRenderingStrategy
 import org.hexworks.zircon.internal.component.renderer.DefaultHeaderRenderer
+import org.hexworks.zircon.padLineEnd
 import org.junit.Before
 import org.junit.Test
 
@@ -35,10 +36,10 @@ class DefaultHeaderTest : ComponentImplementationTest<DefaultHeader>() {
     @Before
     override fun setUp() {
         rendererStub = ComponentRendererStub(DefaultHeaderRenderer())
-        graphics = DrawSurfaces.tileGraphicsBuilder().withSize(SIZE_3_4).build()
+        graphics = DrawSurfaces.tileGraphicsBuilder().withSize(SIZE_10_4).build()
         target = DefaultHeader(
                 componentMetadata = ComponentMetadata(
-                        size = SIZE_3_4,
+                        size = SIZE_10_4,
                         relativePosition = POSITION_2_3,
                         componentStyleSet = COMPONENT_STYLES,
                         tileset = TILESET_REX_PAINT_20X20),
@@ -69,11 +70,11 @@ class DefaultHeaderTest : ComponentImplementationTest<DefaultHeader>() {
         rendererStub.render(graphics, ComponentRenderContext(target))
         // Careful, the last line has a trailing space
         assertThat(graphics.convertCharacterTilesToString()).isEqualTo("""
-            But
-            ton
-             te
-            xt 
-        """.trimIndent())
+            Button tex
+            t
+             
+             
+        """.trimIndent().padLineEnd(SIZE_10_4.width))
     }
 
     companion object {

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/DefaultHeaderTest.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/DefaultHeaderTest.kt
@@ -8,9 +8,11 @@ import org.hexworks.zircon.api.color.TileColor
 import org.hexworks.zircon.api.component.ComponentStyleSet
 import org.hexworks.zircon.api.component.Header
 import org.hexworks.zircon.api.component.data.ComponentMetadata
+import org.hexworks.zircon.api.component.renderer.ComponentRenderContext
 import org.hexworks.zircon.api.component.renderer.ComponentRenderer
 import org.hexworks.zircon.api.graphics.TileGraphics
 import org.hexworks.zircon.api.uievent.Pass
+import org.hexworks.zircon.convertCharacterTilesToString
 import org.hexworks.zircon.internal.component.renderer.DefaultComponentRenderingStrategy
 import org.hexworks.zircon.internal.component.renderer.DefaultHeaderRenderer
 import org.junit.Before
@@ -59,6 +61,19 @@ class DefaultHeaderTest : ComponentImplementationTest<DefaultHeader>() {
     @Test
     fun shouldNotAcceptGivenFocus() {
         assertThat(target.focusGiven()).isEqualTo(Pass)
+    }
+
+    @Test
+    fun shouldGenerateProperTiles() {
+        rendererStub.clear()
+        rendererStub.render(graphics, ComponentRenderContext(target))
+        // Careful, the last line has a trailing space
+        assertThat(graphics.convertCharacterTilesToString()).isEqualTo("""
+            But
+            ton
+             te
+            xt 
+        """.trimIndent())
     }
 
     companion object {

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/DefaultHeaderTest.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/internal/component/impl/DefaultHeaderTest.kt
@@ -70,8 +70,8 @@ class DefaultHeaderTest : ComponentImplementationTest<DefaultHeader>() {
         rendererStub.render(graphics, ComponentRenderContext(target))
         // Careful, the last line has a trailing space
         assertThat(graphics.convertCharacterTilesToString()).isEqualTo("""
-            Button tex
-            t
+            Button
+            text
              
              
         """.trimIndent().padLineEnd(SIZE_10_4.width))


### PR DESCRIPTION
Pretty self-explanatory. It seems like headers should wrap the same way paragraphs do.

I recommend looking at the commits individually; I took deliberate incremental steps towards what you see in the final diff output.

Closes #367.