### PR TITLE
Table fragment updates on changes

### DIFF
--- a/zircon.jvm.examples/src/main/kotlin/org/hexworks/zircon/examples/fragments/table/TableExample.kt
+++ b/zircon.jvm.examples/src/main/kotlin/org/hexworks/zircon/examples/fragments/table/TableExample.kt
@@ -1,6 +1,7 @@
 package org.hexworks.zircon.examples.fragments.table
 
 import org.hexworks.cobalt.databinding.api.binding.bindTransform
+import org.hexworks.cobalt.databinding.api.collection.ListProperty
 import org.hexworks.cobalt.databinding.api.extension.toProperty
 import org.hexworks.cobalt.databinding.api.value.ObservableValue
 import org.hexworks.zircon.api.*
@@ -24,6 +25,8 @@ import org.hexworks.zircon.api.uievent.ComponentEventType
 object TableExample {
 
     private val theme = ColorThemes.zenburnVanilla()
+
+    private val data: ListProperty<Person> = 2.randomPersons().toProperty()
 
     @JvmStatic
     fun main(args: Array<String>) {
@@ -54,7 +57,7 @@ object TableExample {
     private fun buildTable(): Table<Person> =
         Fragments
                 // TODO: Use an observable list and add UI elements to add/remove elements
-            .table(50.randomPersons())
+            .table(data)
             .withHeight(20)
             .withColumnSpacing(1)
             .withRowSpacing(0)
@@ -132,6 +135,26 @@ object TableExample {
                         .apply {
                             currentValue = personObs.value.wage.value
                             currentValueProperty.bindTransform { personObs.value.wage.updateValue(it) }
+                        },
+                    Components
+                        .button()
+                        .withText("add person")
+                        .build()
+                        .apply {
+                            processComponentEvents(ComponentEventType.ACTIVATED) {
+                                data.add(randomPerson())
+                            }
+                        },
+                    Components
+                        .button()
+                        .withText("remove person")
+                        .build()
+                        .apply {
+                            processComponentEvents(ComponentEventType.ACTIVATED) {
+                                if (data.isNotEmpty()) {
+                                    data.removeAt(data.lastIndex)
+                                }
+                            }
                         }
                 )
             }

--- a/zircon.jvm.examples/src/main/kotlin/org/hexworks/zircon/examples/fragments/table/TableExample.kt
+++ b/zircon.jvm.examples/src/main/kotlin/org/hexworks/zircon/examples/fragments/table/TableExample.kt
@@ -138,23 +138,46 @@ object TableExample {
                         },
                     Components
                         .button()
-                        .withText("add person")
+                        .withSize(contentSize.withHeight(1))
                         .build()
                         .apply {
+                            textProperty.updateFrom(personObs.bindTransform { "Delete ${it.firstName} ${it.lastName}" })
                             processComponentEvents(ComponentEventType.ACTIVATED) {
-                                data.add(randomPerson())
+                                data.remove(personObs.value)
                             }
                         },
                     Components
-                        .button()
-                        .withText("remove person")
+                        .hbox()
+                        .withSpacing(1)
+                        .withSize(contentSize.withHeight(1))
                         .build()
                         .apply {
-                            processComponentEvents(ComponentEventType.ACTIVATED) {
-                                if (data.isNotEmpty()) {
-                                    data.removeAt(data.lastIndex)
-                                }
-                            }
+                            addComponents(
+                                Components
+                                    .button()
+                                    .withText("+")
+                                    .build()
+                                    .apply {
+                                        processComponentEvents(ComponentEventType.ACTIVATED) {
+                                            data.add(randomPerson())
+                                        }
+                                    },
+                                Components
+                                    .label()
+                                    .withText("random Person")
+                                    .build(),
+                                Components
+                                    .button()
+                                    .withText("-")
+                                    .build()
+                                    .apply {
+                                        processComponentEvents(ComponentEventType.ACTIVATED) {
+                                            if (data.isNotEmpty()) {
+                                                data.removeAt(data.lastIndex)
+                                            }
+                                        }
+                                    }
+                            )
                         }
                 )
             }


### PR DESCRIPTION
A small update to the table fragment: `DefaultTable` now actually updates when the underlying observable list changes. I also extended the `TableExample` accordingly. Have a look:
![table_example_add_remove](https://user-images.githubusercontent.com/450955/114617085-f17e7480-9ca7-11eb-95d9-a46b5392ead8.gif)
