### PR TITLE
Add custom property support to AppConfig.

### DIFF
--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfigKey.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/application/AppConfigKey.kt
@@ -1,0 +1,12 @@
+package org.hexworks.zircon.api.application
+
+import org.hexworks.zircon.api.builder.application.AppConfigBuilder
+
+/**
+ * This simple interface is used to set and retrieve custom properties on [AppConfig]
+ * in a typesafe way.
+ *
+ * @see AppConfigBuilder.withProperty
+ * @see AppConfig.getProperty
+ */
+interface AppConfigKey<T>

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/application/AppConfigBuilder.kt
@@ -191,6 +191,27 @@ data class AppConfigBuilder(
         )
     }
 
+    /**
+     * Adds a custom property into the AppConfig object. This can later be retrieved using [AppConfig.getProperty].
+     *
+     * ### End Developers
+     *
+     * You probably don't need to call this API.
+     *
+     * ### Plugin Developers
+     *
+     * Write extension methods off of [AppConfigBuilder] that call this API in order to enable end developers
+     * to pass configuration in through AppConfig that your plugin can later use. It's recommended that [key]
+     * be an `object` with minimal visibility (e.g. `internal`).
+     *
+     * @sample org.hexworks.zircon.api.application.AppConfigTest.propertyExample
+     */
+    fun <T : Any> withProperty(key: AppConfigKey<T>, value: T): AppConfigBuilder = also {
+        config = config.copy(
+            customProperties = config.customProperties + (key to value)
+        )
+    }
+
     @Deprecated("This will be removed in the next version, as the behavior is inconsistent.")
     fun withFullScreen(screenWidth: Int, screenHeight: Int) = also {
         throw UnsupportedOperationException("Unstable api, use withFullScreen(true) instead")

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/cobalt/test/MaybeAssert.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/cobalt/test/MaybeAssert.kt
@@ -1,0 +1,35 @@
+package org.hexworks.cobalt.test
+
+import org.assertj.core.api.AbstractObjectAssert
+import org.hexworks.cobalt.datatypes.Maybe
+
+fun <T> assertThat(maybe: Maybe<T>) = MaybeAssert(maybe)
+
+class MaybeAssert<T>(actual: Maybe<T>) : AbstractObjectAssert<MaybeAssert<T>, Maybe<T>>(actual, MaybeAssert::class.java) {
+    fun isPresent() = also {
+        isNotNull
+
+        if (!actual.isPresent) {
+            failWithMessage("Expected a value to be present but was empty")
+        }
+    }
+
+    fun isEmpty() = also {
+        isNotNull
+
+        if (!actual.isEmpty()) {
+            failWithMessage("Expected no value to be present but contained %s", actual.get())
+        }
+    }
+
+    fun hasValue(expected: T) = also {
+        isNotNull
+
+        if (actual.isEmpty()) {
+            failWithMessage("Expected a value to be present but was empty")
+        }
+        if (actual.get() != expected) {
+            failWithMessage("Expected actual <%s> to be equal to <%s> but was not", actual.get(), expected)
+        }
+    }
+}

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/api/application/AppConfigTest.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/api/application/AppConfigTest.kt
@@ -1,9 +1,13 @@
 package org.hexworks.zircon.api.application
 
 import org.assertj.core.api.Assertions.assertThat
+import org.hexworks.cobalt.test.assertThat
 import org.hexworks.zircon.api.builder.application.AppConfigBuilder
 import org.hexworks.zircon.api.color.ANSITileColor
 import org.junit.Test
+
+private object TestAppConfigKey : AppConfigKey<String>
+private object TestAppConfigKey2 : AppConfigKey<String>
 
 class AppConfigTest {
 
@@ -27,6 +31,60 @@ class AppConfigTest {
                 .isEqualTo(IS_BLINKING)
         assertThat(target.isClipboardAvailable)
                 .isEqualTo(HAS_CLIPBOARD)
+    }
+
+    @Test
+    fun propertyUnset() {
+        val appConfig = AppConfigBuilder.newBuilder().build()
+        assertThat(appConfig[TestAppConfigKey])
+            .isEmpty()
+    }
+
+    @Test
+    fun propertySet() {
+        val appConfig = AppConfigBuilder.newBuilder()
+            .withProperty(TestAppConfigKey, "foo")
+            .build()
+        assertThat(appConfig[TestAppConfigKey])
+            .hasValue("foo")
+    }
+
+    @Test
+    fun propertyOverwrite() {
+        val appConfig = AppConfigBuilder.newBuilder()
+            .withProperty(TestAppConfigKey, "foo")
+            .withProperty(TestAppConfigKey, "bar")
+            .build()
+        assertThat(appConfig[TestAppConfigKey])
+            .hasValue("bar")
+    }
+
+    @Test
+    fun propertyMultiple() {
+        val appConfig = AppConfigBuilder.newBuilder()
+            .withProperty(TestAppConfigKey, "foo")
+            .withProperty(TestAppConfigKey2, "bar")
+            .build()
+        assertThat(appConfig[TestAppConfigKey])
+            .hasValue("foo")
+        assertThat(appConfig[TestAppConfigKey2])
+            .hasValue("bar")
+    }
+
+    @Test
+    fun propertyExample() {
+        // Plugin API
+        val key = object : AppConfigKey<Int> {} // use a real internal or private `object`, not an anonymous one!
+        fun AppConfigBuilder.enableCoolFeature() = also { withProperty(key, 42) }
+
+        // User code
+        val appConfig = AppConfigBuilder.newBuilder()
+            .enableCoolFeature()
+            .build()
+
+        // Plugin internals
+        assertThat(appConfig[key])
+            .hasValue(42)
     }
 
     companion object {


### PR DESCRIPTION
This enables plugin authors to easily set and retrieve configuration options
for the end developer.

Closes #380.