### PR TITLE
Upgrade Mockito and Mockito-Kotlin.

### DIFF
--- a/buildSrc/src/main/kotlin/TestLibs.kt
+++ b/buildSrc/src/main/kotlin/TestLibs.kt
@@ -14,8 +14,8 @@ object TestLibs {
     const val logbackCore = "ch.qos.logback:logback-core:$logbackVersion"
 
     const val junit = "junit:junit:$junitVersion"
-    const val mockitoAll = "org.mockito:mockito-all:$mockitoVersion"
-    const val mockitoKotlin = "com.nhaarman:mockito-kotlin:$mockitoKotlinVersion"
+    const val mockitoCore = "org.mockito:mockito-core:$mockitoVersion"
+    const val mockitoKotlin = "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     const val assertjCore = "org.assertj:assertj-core:$assertjVersion"
     const val assertk = "com.willowtreeapps.assertk:assertk-jvm:$assertkVersion"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,8 +13,8 @@ object Versions {
     const val filtersVersion = "2.0.235-1"
 
     const val junitVersion = "4.12"
-    const val mockitoVersion = "1.10.19"
-    const val mockitoKotlinVersion = "1.6.0"
+    const val mockitoVersion = "3.9.0"
+    const val mockitoKotlinVersion = "3.1.0"
     const val assertjVersion = "3.6.2"
     const val assertkVersion = "0.23"
 }

--- a/zircon.core/build.gradle.kts
+++ b/zircon.core/build.gradle.kts
@@ -12,7 +12,7 @@ import TestLibs.assertjCore
 import TestLibs.kotlinTestAnnotationsCommon
 import TestLibs.kotlinTestCommon
 import TestLibs.logbackCore
-import TestLibs.mockitoAll
+import TestLibs.mockitoCore
 import TestLibs.mockitoKotlin
 
 import org.jetbrains.dokka.gradle.DokkaTask
@@ -65,7 +65,7 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit"))
 
-                implementation(mockitoAll)
+                implementation(mockitoCore)
                 implementation(mockitoKotlin)
                 implementation(assertjCore)
                 implementation(logbackClassic)

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/api/animation/DefaultAnimationRunnerTest.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/api/animation/DefaultAnimationRunnerTest.kt
@@ -1,50 +1,46 @@
 package org.hexworks.zircon.api.animation
 
 import org.assertj.core.api.Assertions.assertThat
+import org.hexworks.cobalt.core.api.UUID
 import org.hexworks.cobalt.core.platform.factory.UUIDFactory
-
-import org.hexworks.zircon.api.application.AppConfig
 import org.hexworks.zircon.api.builder.animation.AnimationBuilder
 import org.hexworks.zircon.api.builder.grid.TileGridBuilder
 import org.hexworks.zircon.api.data.Position
 import org.hexworks.zircon.api.data.Size
-import org.hexworks.zircon.internal.animation.impl.DefaultAnimation
-import org.hexworks.zircon.internal.animation.impl.DefaultAnimationFrame
 import org.hexworks.zircon.internal.animation.DefaultAnimationRunner
 import org.hexworks.zircon.internal.animation.InternalAnimation
+import org.hexworks.zircon.internal.animation.impl.DefaultAnimationFrame
 import org.hexworks.zircon.internal.resource.BuiltInCP437TilesetResource
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnit
+import org.mockito.junit.MockitoRule
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 import java.util.concurrent.locks.ReentrantLock
 
 @Suppress("UNUSED_VARIABLE")
 class DefaultAnimationRunnerTest {
+    @get:Rule
+    val mockitoRule: MockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS)
 
-    private lateinit var target: DefaultAnimationRunner
+    private val target = DefaultAnimationRunner()
 
     @Mock
     lateinit var animationMock: InternalAnimation
 
-    @Before
-    fun setUp() {
-        MockitoAnnotations.initMocks(this)
-        AppConfig.newBuilder().enableBetaFeatures().build()
-        target = DefaultAnimationRunner()
-    }
-
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun shouldCloseProperlyWhenClosed() {
+        whenever(animationMock.id).thenReturn(UUID.randomUUID())
+        whenever(animationMock.isLoopedIndefinitely).thenReturn(false)
+
+        target.start(animationMock)
         target.close()
 
-        target.start(DefaultAnimation(
-                tick = 1,
-                loopCount = 1,
-                totalFrameCount = 1,
-                uniqueFrameCount = 1,
-                frames = listOf()))
+        assertThat(target.closed).isTrue()
+        verify(animationMock).removeCurrentFrame()
     }
 
     @Test
@@ -68,8 +64,8 @@ class DefaultAnimationRunnerTest {
         val lock = ReentrantLock()
         val cond = lock.newCondition()
 
-        Mockito.`when`(animationMock.id).thenReturn(uuid)
-        Mockito.`when`(animationMock.isLoopedIndefinitely).thenReturn(false)
+        whenever(animationMock.id).thenReturn(uuid)
+        whenever(animationMock.isLoopedIndefinitely).thenReturn(false)
 
         val result = target.start(animationMock)
 
@@ -82,14 +78,14 @@ class DefaultAnimationRunnerTest {
         val uuid = UUIDFactory.randomUUID()
         val currFrame = DefaultAnimationFrame(Size.one(), listOf(), 1)
 
-//        Mockito.`when`(animationMock.id).thenReturn(uuid)
-//        Mockito.`when`(animationMock.isLoopedIndefinitely).thenReturn(false)
-//        Mockito.`when`(animationMock.fetchNextFrame()).thenReturn(Maybe.empty())
-//        Mockito.`when`(animationMock.fetchCurrentFrame())
+//        whenever(animationMock.id).thenReturn(uuid)
+//        whenever(animationMock.isLoopedIndefinitely).thenReturn(false)
+//        whenever(animationMock.fetchNextFrame()).thenReturn(Maybe.empty())
+//        whenever(animationMock.fetchCurrentFrame())
 //                .then {
 //                    currFrame
 //                }
-//        Mockito.`when`(animationMock.hasNextFrame()).thenReturn(false)
+//        whenever(animationMock.hasNextFrame()).thenReturn(false)
 
         val tileGrid = TileGridBuilder.newBuilder()
                 .withSize(Size.create(50, 50))

--- a/zircon.jvm.libgdx/build.gradle.kts
+++ b/zircon.jvm.libgdx/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
 
         with(TestLibs) {
             testImplementation(junit)
-            testImplementation(mockitoAll)
+            testImplementation(mockitoCore)
             testImplementation(assertjCore)
         }
     }

--- a/zircon.jvm.swing/build.gradle.kts
+++ b/zircon.jvm.swing/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
 
         with(TestLibs) {
             testImplementation(junit)
-            testImplementation(mockitoAll)
+            testImplementation(mockitoCore)
             testImplementation(assertjCore)
         }
     }


### PR DESCRIPTION
* Upgrade test library versions.
* Replace initMocks with JUnit rules.
* Use strict stubs.
* Replace "Mockito.`when`" with "whenever".
* Fix a couple tests that were broken.

Closes #384.