### PR TITLE
Added a Builder Implementation for StackedTile and allowing that implementation to be used in TopGameAreaRender and TopFrontGameAreaRender

### DIFF
--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/data/StackedTileBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/data/StackedTileBuilder.kt
@@ -52,7 +52,7 @@ public class StackedTileBuilder private constructor(
     override fun build(): StackedTile {
         return DefaultStackedTile(
             baseTile = baseTile,
-            rest = tileStack.toPersistentList()
+            rest = tileStack.reversed().toPersistentList()
             )
     }
 

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/data/StackedTileBuilder.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/builder/data/StackedTileBuilder.kt
@@ -1,0 +1,73 @@
+package org.hexworks.zircon.api.builder.data
+
+import kotlinx.collections.immutable.toPersistentList
+import org.hexworks.zircon.api.builder.Builder
+import org.hexworks.zircon.api.data.StackedTile
+import org.hexworks.zircon.api.data.Tile
+import org.hexworks.zircon.internal.data.DefaultStackedTile
+
+/**
+ * Builds [StackedTile]s
+ * Defaults:
+ * - BaseTile is the default Tile
+ * - TileStack is an empty Stack
+ *
+ */
+public class StackedTileBuilder private constructor(
+    private var baseTile: Tile,
+    private val tileStack: MutableList<Tile>
+): Builder<StackedTile> {
+
+    // The first element of the list is the top of the stack!
+
+    val top: Tile = tileStack.firstOrNull() ?: baseTile
+
+    /**
+     * Sets the BaseTile to the desired [tile]
+     */
+    public fun withBaseTile(tile: Tile): StackedTileBuilder = also {
+        baseTile = tile
+    }
+
+    /**
+     * Pushes the [tile] to the stack
+     */
+    public fun withPushedTile(tile: Tile): StackedTileBuilder = also {
+        tileStack.add(0, tile)
+    }
+
+    /**
+     * Pushes the [tiles] to the stack in reverse order.
+     * The first Tile in the list will be on top of the stack
+     */
+    public fun withPushedTiles(vararg tiles: Tile): StackedTileBuilder = also {
+        tiles.reversed().forEach { tile ->
+            withPushedTile(tile)
+        }
+    }
+
+    /**
+     * Builds the StackedTile
+     */
+    override fun build(): StackedTile {
+        return DefaultStackedTile(
+            baseTile = baseTile,
+            rest = tileStack.toPersistentList()
+            )
+    }
+
+    override fun createCopy(): Builder<StackedTile> = StackedTileBuilder(baseTile, tileStack)
+
+    companion object {
+        /**
+         * Returns a builder with the default configuration
+         */
+        public fun newBuilder(): StackedTileBuilder{
+            return StackedTileBuilder(
+                baseTile = Tile.defaultTile(),
+                tileStack = mutableListOf()
+                )
+        }
+    }
+
+}

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/data/Tile.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/data/Tile.kt
@@ -1,6 +1,7 @@
 package org.hexworks.zircon.api.data
 
 import org.hexworks.zircon.api.behavior.Cacheable
+import org.hexworks.zircon.api.builder.Builder
 import org.hexworks.zircon.api.builder.data.TileBuilder
 import org.hexworks.zircon.api.color.TileColor
 import org.hexworks.zircon.api.graphics.DrawSurface
@@ -137,7 +138,7 @@ interface Tile : Cacheable, StyleSet {
      * Creates a new [TileBuilder] preconfigured with the contents of
      * this [Tile].
      */
-    fun toBuilder(): TileBuilder
+    fun toBuilder(): Builder<Tile>
 
     companion object {
 

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/game/GameAreaTileFilter.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/api/game/GameAreaTileFilter.kt
@@ -3,10 +3,12 @@
 package org.hexworks.zircon.api.game
 
 import org.hexworks.zircon.api.Beta
+import org.hexworks.zircon.api.builder.Builder
 import org.hexworks.zircon.api.builder.data.TileBuilder
 import org.hexworks.zircon.api.data.BlockTileType
 import org.hexworks.zircon.api.data.Position3D
 import org.hexworks.zircon.api.data.Size3D
+import org.hexworks.zircon.api.data.Tile
 
 @Beta
 interface GameAreaTileFilter {
@@ -15,8 +17,8 @@ interface GameAreaTileFilter {
         visibleSize: Size3D,
         offsetPosition: Position3D,
         blockTileType: BlockTileType,
-        tileBuilder: TileBuilder,
-    ): TileBuilder
+        tileBuilder: Builder<Tile>,
+    ): Builder<Tile>
 
     operator fun plus(other: GameAreaTileFilter): GameAreaTileFilter {
         return CompositeGameAreaTileFilter(this, other)
@@ -30,8 +32,8 @@ interface GameAreaTileFilter {
             visibleSize: Size3D,
             offsetPosition: Position3D,
             blockTileType: BlockTileType,
-            tileBuilder: TileBuilder
-        ): TileBuilder {
+            tileBuilder: Builder<Tile>
+        ): Builder<Tile> {
             val prev = first.transform(
                 visibleSize = visibleSize,
                 offsetPosition = offsetPosition,
@@ -53,8 +55,8 @@ interface GameAreaTileFilter {
                 visibleSize: Size3D,
                 offsetPosition: Position3D,
                 blockTileType: BlockTileType,
-                tileBuilder: TileBuilder
-            ): TileBuilder {
+                tileBuilder: Builder<Tile>
+            ): Builder<Tile> {
                 return tileBuilder
             }
 

--- a/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/data/DefaultStackedTile.kt
+++ b/zircon.core/src/commonMain/kotlin/org/hexworks/zircon/internal/data/DefaultStackedTile.kt
@@ -4,6 +4,7 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
 import org.hexworks.zircon.api.Beta
+import org.hexworks.zircon.api.builder.data.StackedTileBuilder
 import org.hexworks.zircon.api.builder.data.TileBuilder
 import org.hexworks.zircon.api.color.TileColor
 import org.hexworks.zircon.api.data.*
@@ -74,7 +75,13 @@ data class DefaultStackedTile(
 
     override fun asGraphicalTileOrNull() = top.asGraphicalTileOrNull()
 
-    override fun toBuilder(): TileBuilder {
-        throw UnsupportedOperationException("This operation is not implemented yet")
+    override fun toBuilder(): StackedTileBuilder {
+        return StackedTileBuilder.newBuilder()
+            .apply {
+                this.withBaseTile(baseTile)
+                rest.forEach { tile -> // The List "rest" is a stack, where the last element of the list is on top of the stack
+                    this.withPushedTile(tile)
+                }
+            }
     }
 }

--- a/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/api/builder/StackedTileBuilderTest.kt
+++ b/zircon.core/src/jvmTest/kotlin/org/hexworks/zircon/api/builder/StackedTileBuilderTest.kt
@@ -1,0 +1,75 @@
+package org.hexworks.zircon.api.builder
+
+import org.hexworks.zircon.api.builder.data.StackedTileBuilder
+import org.hexworks.zircon.api.color.ANSITileColor
+import org.hexworks.zircon.api.color.TileColor
+import org.hexworks.zircon.api.data.StackedTile
+import org.hexworks.zircon.api.data.Tile
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class StackedTileBuilderTest {
+
+    private val t1 = Tile.newBuilder()
+        .withCharacter('1')
+        .withForegroundColor(ANSITileColor.RED)
+        .withBackgroundColor(TileColor.transparent())
+        .buildCharacterTile()
+    private val t2 = Tile.newBuilder()
+        .withCharacter('2')
+        .withForegroundColor(ANSITileColor.GREEN)
+        .withBackgroundColor(TileColor.transparent())
+        .buildCharacterTile()
+    private val t3 = Tile.newBuilder()
+        .withCharacter('3')
+        .withForegroundColor(ANSITileColor.BLUE)
+        .withBackgroundColor(TileColor.transparent())
+        .buildCharacterTile()
+
+    @Test
+    fun shouldBuildProperStack(){
+        val builtTile = StackedTileBuilder.newBuilder()
+            .withBaseTile(t1)
+            .withPushedTile(t2)
+            .build()
+
+        builtTile.shouldBeComposedOf(t1, t2)
+    }
+
+    @Test
+    fun shouldPushProperly(){
+        val builtTile = StackedTileBuilder.newBuilder()
+            .withBaseTile(t1)
+            .withPushedTile(t2)
+            .withPushedTile(t3)
+            .build()
+
+        builtTile.shouldBeComposedOf(t1, t2, t3)
+    }
+
+    @Test
+    fun shouldPushAlotTilesProperly(){
+        val builtTile = StackedTileBuilder.newBuilder()
+            .withBaseTile(t1)
+            .withPushedTiles(t3, t2)
+            .build()
+
+        builtTile.shouldBeComposedOf(t1, t2, t3)
+    }
+
+    private fun StackedTile.shouldBeComposedOf(vararg expectedTiles: Tile) {
+        val expectedSize = expectedTiles.size
+        assertTrue(expectedSize > 0, "Can not assert a StackedTile without expected tiles!")
+
+        val expectedBaseTile = expectedTiles.first()
+        val expectedTopTile = expectedTiles.last()
+
+        assertEquals(expectedSize, this.tiles.size, "$this should contain $expectedSize tiles")
+        assertEquals(expectedBaseTile, this.baseTile, "Base tile not equal to $expectedBaseTile")
+        assertEquals(expectedTopTile, this.top, "Top tile should be $expectedTopTile")
+        expectedTiles.forEachIndexed { index, expectedTile ->
+            assertEquals(expectedTile, this.tiles[index], "Tile at stack index $index not equal to the expected tile.")
+        }
+    }
+}


### PR DESCRIPTION
When utilizing `StackedTile`s in a GameArea composed of Blocks, the `TopDownGameAreaRenderer` and the `TopDownFrontGameAreaRenderer` would complain about StackedTile s missing implementation of `Tile#toBuilder()`. This Pull Request adds that functionality, allowing `StackedTile` to render.

The only thing I did aside from supplying my builder, was to change the existing `Tile#toBuilder()` method signature from `TileBuilder` to `Builder<Tile>` allowing my StackedTileBuilder to implement that method.

If I missed anything I will gladly add it.

